### PR TITLE
Use built image instead of pulling new image every time

### DIFF
--- a/helm_deploy/wordpress/templates/wp-multisite-cron.yaml
+++ b/helm_deploy/wordpress/templates/wp-multisite-cron.yaml
@@ -13,7 +13,7 @@ spec:
         spec:
           containers:
           - name: nginx-curl
-            image: nginxinc/nginx-unprivileged
+            image: {{ .Values.nginx.image.repository }}
             imagePullPolicy: IfNotPresent
             args:
             - curl


### PR DESCRIPTION
Because CP change nodes frequently the `IfNotPresent` flag was always being called and therefore the image was constantly being pulled maxing out the Docker limits. Changing this to use the specific deploy version of nginx which should result in much less image pulls.