### PR TITLE
Add prisonandprobationjobs.gov.uk (PPJ) domain to ingress

### DIFF
--- a/helm_deploy/wordpress/templates/ingress.yaml
+++ b/helm_deploy/wordpress/templates/ingress.yaml
@@ -54,6 +54,12 @@ spec:
   - hosts:
     - www.brookhouseinquiry.org.uk
     secretName: brookhouse-www-cert
+  - hosts:
+    - prisonandprobationjobs.gov.uk
+    secretName: ppj-cert
+  - hosts:
+    - www.prisonandprobationjobs.gov.uk
+    secretName: ppj-www-cert
     {{- end }}
   rules:
   - host: {{ .Values.domain }}
@@ -178,6 +184,26 @@ spec:
             port:
               number: 8080
   - host: www.brookhouseinquiry.org.uk
+    http:
+      paths:
+      - path: /
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: wordpress
+            port:
+              number: 8080
+  - host: prisonandprobationjobs.gov.uk
+    http:
+      paths:
+      - path: /
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: wordpress
+            port:
+              number: 8080
+  - host: www.prisonandprobationjobs.gov.uk
     http:
       paths:
       - path: /


### PR DESCRIPTION
Add PPJ domain to our ingress for migration to hale platform.