### PR TITLE
Disable HPA while we investigate pod missing file bug

### DIFF
--- a/helm_deploy/wordpress/values.yaml
+++ b/helm_deploy/wordpress/values.yaml
@@ -20,12 +20,12 @@ wp:
     # Default if HPA is not turned on
     replicaCount:
       prod: 3
-      staging: 3
+      staging: 2
       dev: 1
       demo: 2
 
 hpa:
-  enabled: true
+  enabled: false
 
 cron:
   feedparser:


### PR DESCRIPTION
We're observing an bug where pods that have just been created occasionally have missing WP files. We want to fix the pod count and turn off the autoscaler until we can determine the cause of this bug.