### PR TITLE
Reduce Sentry Replay value to only errors

### DIFF
--- a/opt/scripts/config.sh
+++ b/opt/scripts/config.sh
@@ -27,8 +27,7 @@ wp config set WP_SENTRY_ENV "\$_SERVER['WP_ENVIRONMENT_TYPE']" --raw
 wp config set WP_SENTRY_BROWSER_ADMIN_ENABLED true --raw
 wp config set WP_SENTRY_BROWSER_LOGIN_ENABLED true --raw
 wp config set WP_SENTRY_BROWSER_FRONTEND_ENABLED true --raw
-wp config set WP_SENTRY_BROWSER_TRACES_SAMPLE_RATE "0.3" --raw # sample ~30% of traffic
-wp config set WP_SENTRY_BROWSER_REPLAYS_SESSION_SAMPLE_RATE "0.1" --raw
+wp config set WP_SENTRY_BROWSER_TRACES_SAMPLE_RATE "0.2" --raw # sample ~30% of traffic
 wp config set WP_SENTRY_BROWSER_REPLAYS_ON_ERROR_SAMPLE_RATE "1.0" --raw
 
 #WP core install


### PR DESCRIPTION
I've completely removed using this constant so that we don't collect Replays unless they are errors, `WP_SENTRY_BROWSER_REPLAYS_SESSION_SAMPLE_RATE`.