### PR TITLE
Add victims code domain redirect

### DIFF
--- a/helm_deploy/wordpress/templates/ingress.yaml
+++ b/helm_deploy/wordpress/templates/ingress.yaml
@@ -17,6 +17,9 @@ metadata:
         auth_basic off;
         return 301 https://raw.githubusercontent.com/ministryofjustice/security-guidance/main/contact/vulnerability-disclosure-security.txt;
         }
+        if ($host = 'victimscode.org.uk') {
+          return 301 https://victimandwitnessinformation.org.uk/your-rights/as-a-victim;
+        }
 spec:
   ingressClassName: modsec
   tls:
@@ -107,13 +110,13 @@ spec:
   - hosts:
     - members.layobservers.org
     secretName: layobservers-members-cert
-  - hosts:
+- hosts:
     - victimandwitnessinformation.org.uk
     secretName: victimandwitnessinformation-cert
-  - hosts:
+- hosts:
     - www.victimandwitnessinformation.org.uk
     secretName: victimandwitnessinformation-www-cert
-  - hosts:
+- hosts:
     - victimscode.org.uk
     secretName: victimscode-cert
     {{- end }}

--- a/helm_deploy/wordpress/templates/ingress.yaml
+++ b/helm_deploy/wordpress/templates/ingress.yaml
@@ -110,13 +110,13 @@ spec:
   - hosts:
     - members.layobservers.org
     secretName: layobservers-members-cert
-- hosts:
+  - hosts:
     - victimandwitnessinformation.org.uk
     secretName: victimandwitnessinformation-cert
-- hosts:
+  - hosts:
     - www.victimandwitnessinformation.org.uk
     secretName: victimandwitnessinformation-www-cert
-- hosts:
+  - hosts:
     - victimscode.org.uk
     secretName: victimscode-cert
     {{- end }}


### PR DESCRIPTION
We have been asked to create a redirect on the platform that directs traffic from victimscode.org.uk to victimandwitnessinformation.org.uk/your-rights/as-a-victim