### PR TITLE
Update WordPress and fix nginx locally

### DIFF
--- a/nginx.local.dockerfile
+++ b/nginx.local.dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/arm64v8 arm64v8/nginx
+FROM --platform=linux/arm64v8 arm64v8/nginx:1.25.2
 
 RUN apt-get -y update
 RUN apt-get -y install vim
@@ -9,5 +9,5 @@ COPY opt/nginx/localwordpress.conf /etc/nginx/conf.d/
 
 RUN rm -r /etc/nginx/conf.d/default.conf
 
-EXPOSE 443 
+EXPOSE 443
 EXPOSE 8080

--- a/wordpress.dockerfile
+++ b/wordpress.dockerfile
@@ -5,7 +5,7 @@
 # ##################################################
 
 # Build multisite
-FROM --platform=linux/amd64 wordpress:6.4.1-php8.2-fpm-alpine
+FROM --platform=linux/amd64 wordpress:6.4.2-php8.2-fpm-alpine
 
 # Install additional Alpine packages
 RUN apk update && \


### PR DESCRIPTION
- WordPress security patch upgrade to latest version.
- Bug fix. When updating your Mac to the latest version Sonoma 14.2.1 there currently is not compatible nginx image (only the local image) so I've fixed the nginx image to a slightly older version for now. This is a working version.