### PR TITLE
Add CYM (Welsh) subdomain to V&W

### DIFF
--- a/helm_deploy/wordpress/templates/ingress.yaml
+++ b/helm_deploy/wordpress/templates/ingress.yaml
@@ -117,6 +117,9 @@ spec:
     - www.victimandwitnessinformation.org.uk
     secretName: victimandwitnessinformation-www-cert
   - hosts:
+    - cym.victimandwitnessinformation.org.uk
+    secretName: victimandwitnessinformation-cym-cert
+  - hosts:
     - victimscode.org.uk
     secretName: victimscode-cert
     {{- end }}
@@ -423,6 +426,16 @@ spec:
             port:
               number: 8080
   - host: www.victimandwitnessinformation.org.uk
+    http:
+      paths:
+      - path: /
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: wordpress
+            port:
+              number: 8080
+  - host: cym.victimandwitnessinformation.org.uk
     http:
       paths:
       - path: /


### PR DESCRIPTION
We have had confirmation to add the
cym.victimandwitnessinformation.org.uk subdomain to the V&W site.
Changes on CP side have been made and deployed.