### PR TITLE
Add showcase domain TLS cert and route

### DIFF
--- a/helm_deploy/wordpress/values.yaml
+++ b/helm_deploy/wordpress/values.yaml
@@ -117,6 +117,8 @@ ingress:
       certName: andrewmalkinson-www-cert
     - name: hmiprisons.justiceinspectorates.gov.uk
       certName: justiceinspectorates-hmiprisons-cert
+    - name: showcase.websitebuilder.service.justice.gov.uk
+      certName: websitebuilder-showcase-cert
 
 configmap:
   servername: ""


### PR DESCRIPTION
Add new domain showcase.websitebuilder.service.justice.gov.uk for showcase site.