### PR TITLE
Add Avature creds

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -47,6 +47,8 @@ jobs:
         s3-uploads-bucket: ${{ secrets.S3_UPLOADS_BUCKET }}
         s3-uploads-region: ${{ secrets.S3_UPLOADS_REGION }}
         alert-slack-webhook-url: ${{ secrets.ALERT_SLACK_WEBHOOK_URL }}
+        avature-feed-username: ${{ secrets.AVATURE_FEED_USERNAME }}
+        avature-feed-password: ${{ secrets.AVATURE_FEED_PASSWORD }}
 
   deployDemo:
       name: Deploy to Demo Environment
@@ -86,6 +88,8 @@ jobs:
         s3-uploads-bucket: ${{ secrets.S3_UPLOADS_BUCKET }}
         s3-uploads-region: ${{ secrets.S3_UPLOADS_REGION }}
         alert-slack-webhook-url: ${{ secrets.ALERT_SLACK_WEBHOOK_URL }}
+        avature-feed-username: ${{ secrets.AVATURE_FEED_USERNAME }}
+        avature-feed-password: ${{ secrets.AVATURE_FEED_PASSWORD }}
 
   deployStaging:
       name: Deploy to Staging Environment
@@ -125,6 +129,8 @@ jobs:
         s3-uploads-bucket: ${{ secrets.S3_UPLOADS_BUCKET }}
         s3-uploads-region: ${{ secrets.S3_UPLOADS_REGION }}
         alert-slack-webhook-url: ${{ secrets.ALERT_SLACK_WEBHOOK_URL }}
+        avature-feed-username: ${{ secrets.AVATURE_FEED_USERNAME }}
+        avature-feed-password: ${{ secrets.AVATURE_FEED_PASSWORD }}
 
   deployProd:
       name: Deploy to Production Environment
@@ -165,3 +171,5 @@ jobs:
         s3-uploads-bucket: ${{ secrets.S3_UPLOADS_BUCKET }}
         s3-uploads-region: ${{ secrets.S3_UPLOADS_REGION }}
         alert-slack-webhook-url: ${{ secrets.ALERT_SLACK_WEBHOOK_URL }}
+        avature-feed-username: ${{ secrets.AVATURE_FEED_USERNAME }}
+        avature-feed-password: ${{ secrets.AVATURE_FEED_PASSWORD }}

--- a/.github/workflows/rw-build-image.yaml
+++ b/.github/workflows/rw-build-image.yaml
@@ -69,6 +69,10 @@ on:
         required: true
       alert-slack-webhook-url:
         required: true
+      avature-feed-username:
+        required: true
+      avature-feed-password:
+        required: true
 
 jobs:
   buildImage:
@@ -216,6 +220,8 @@ jobs:
           --set secrets.wpsecureauthsalt=${{ secrets.wp-secure-auth-salt-file }} \
           --set secrets.s3uploadsbucket=${{ secrets.s3-uploads-bucket }} \
           --set secrets.s3uploadsregion=${{ secrets.s3-uploads-region }} \
+          --set secrets.feedparser.avatureFeedUserName=${{ secrets.avature-feed-username }} \
+          --set secrets.feedparser.avatureFeedPassword=${{ secrets.avature-feed-password }} \
           --set alertSecrets.slackWebhookUrl=${{ secrets.alert-slack-webhook-url }} \
           --set configmap.servername=${{ secrets.kube-namespace }}.apps.live.cloud-platform.service.justice.gov.uk \
           --set configmap.envtype=${{ vars.ENV_TYPE }} \

--- a/helm_deploy/wordpress/templates/cron-feedparser.yaml
+++ b/helm_deploy/wordpress/templates/cron-feedparser.yaml
@@ -20,5 +20,7 @@ spec:
                   name: hale-wp-config-{{ .Release.Revision }}
               - secretRef:
                   name: hale-wp-secrets-{{ .Release.Revision }}
+              - secretRef:
+                  name: feed-parser-secrets-{{ .Release.Revision }}
           restartPolicy: OnFailure
 {{- end }}

--- a/helm_deploy/wordpress/templates/secrets.yaml
+++ b/helm_deploy/wordpress/templates/secrets.yaml
@@ -22,4 +22,13 @@ stringData:
   WORDPRESS_SECURE_AUTH_SALT: {{ .Values.secrets.wpsecureauthsalt | b64dec | quote }}
   S3_UPLOADS_BUCKET:  {{ .Values.secrets.s3uploadsbucket }}
   S3_UPLOADS_REGION: {{ .Values.secrets.s3uploadsregion }}
+  ---
+  apiVersion: v1
+kind: Secret
+metadata: 
+  name: feed-parser-secrets-{{ .Release.Revision }} 
+type: Opaque
+stringData:
+  AVATURE_FEED_USERNAME: {{ .Values.secrets.feedparser.avatureFeedUserName }}
+  AVATURE_FEED_PASSWORD: {{ .Values.secrets.feedparser.avatureFeedPassword }}
 {{- end }}

--- a/helm_deploy/wordpress/values.yaml
+++ b/helm_deploy/wordpress/values.yaml
@@ -147,6 +147,10 @@ secrets:
   wpsecureauthsalt: ""
   s3uploadsbucket: ""
   s3uploadsregion: ""
+  feedparser:
+    avatureFeedUserName: ""
+    avatureFeedUserPassword: ""
+
 
 alertSecrets:
   enabled: true

--- a/helm_deploy/wordpress/values.yaml
+++ b/helm_deploy/wordpress/values.yaml
@@ -151,7 +151,6 @@ secrets:
     avatureFeedUserName: ""
     avatureFeedUserPassword: ""
 
-
 alertSecrets:
   enabled: true
   slackWebhookUrl: ""


### PR DESCRIPTION
The new Avature feed is protected by basic auth. This adds in the secrets required for that auth places them in the env for the feed parser microservice to use.