### PR TITLE
Add in new ingress modsec rules

### DIFF
--- a/helm_deploy/wordpress/templates/ingress.yaml
+++ b/helm_deploy/wordpress/templates/ingress.yaml
@@ -34,8 +34,7 @@ metadata:
         ctl:ruleRemoveById=921110"
     {{- if eq .Values.configmap.envtype "staging" }}
       # Allowlist red team IP 08/08/24
-      SecRule REMOTE_ADDR "@ipMatch 81.137.198.207/32" "phase:2,id:200000001,nolog,allow"
-    {{- end }}
+      SecRule REMOTE_ADDR "@ipMatch 81.137.198.207,82.69.80.147/32" "phase:2,id:200000001,nolog,allow"    {{- end }}
     nginx.ingress.kubernetes.io/server-snippet: |
       location = /.well-known/security.txt {
         auth_basic off;

--- a/helm_deploy/wordpress/templates/ingress.yaml
+++ b/helm_deploy/wordpress/templates/ingress.yaml
@@ -34,7 +34,8 @@ metadata:
         ctl:ruleRemoveById=921110"
     {{- if eq .Values.configmap.envtype "staging" }}
       # Allowlist red team IP 08/08/24
-      SecRule REMOTE_ADDR "@ipMatch 81.137.198.207,82.69.80.147/32" "phase:2,id:200000001,nolog,allow"    {{- end }}
+      SecRule REMOTE_ADDR "@ipMatch 81.137.198.207,82.69.80.147/32" "phase:2,id:200000001,nolog,allow"
+    {{- end }}
     nginx.ingress.kubernetes.io/server-snippet: |
       location = /.well-known/security.txt {
         auth_basic off;

--- a/helm_deploy/wordpress/templates/ingress.yaml
+++ b/helm_deploy/wordpress/templates/ingress.yaml
@@ -8,18 +8,32 @@ metadata:
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      # Apply specific WAF rules
       SecRuleEngine On
-      SecDefaultAction "phase:2,pass,log,tag:github_team=hale-platform"
-      SecRuleRemoveById 941100
-      SecRuleRemoveById 941160
-      SecRuleRemoveById 941180
-      SecRuleRemoveById 942230
-      SecRuleRemoveById 933210
-      SecRuleRemoveById 932130
-      SecRuleRemoveById 941140
-      SecRuleRemoveById 941300
-      SecRuleRemoveById 921110
+      SecDefaultAction 
+        "phase:2,\
+        pass,\
+        log,\
+        tag:github_team=hale-platform,\
+        tag:environment=hale-platform-{{ .Values.configmap.envtype }}"
+      # Limit ModSecurity excemptions to only the WP API
+      SecRule REQUEST_URI "@contains /wp-json/" \
+        "id:1000,\
+        phase:2,\
+        pass,\
+        nolog,\
+        ctl:ruleRemoveById=941100,\
+        ctl:ruleRemoveById=941160,\
+        ctl:ruleRemoveById=941180,\
+        ctl:ruleRemoveById=942230,\
+        ctl:ruleRemoveById=933210,\
+        ctl:ruleRemoveById=932130,\
+        ctl:ruleRemoveById=941140,\
+        ctl:ruleRemoveById=932105,\
+        ctl:ruleRemoveById=941300,\
+        ctl:ruleRemoveById=921110"
     {{- if eq .Values.configmap.envtype "staging" }}
+      # Allowlist red team IP 08/08/24
       SecRule REMOTE_ADDR "@ipMatch 81.137.198.207/32" "phase:2,id:200000001,nolog,allow"
     {{- end }}
     nginx.ingress.kubernetes.io/server-snippet: |


### PR DESCRIPTION
- Apply new modSec exemption rules that only target WP API. 
- Add new env tag to ingress to allow for easier filtering.