### PR TITLE
Update GitAction and ingress with WB domain

### DIFF
--- a/.github/workflows/rw-build-image.yaml
+++ b/.github/workflows/rw-build-image.yaml
@@ -223,10 +223,9 @@ jobs:
           --set secrets.feedparser.avatureFeedUserName=${{ secrets.avature-feed-username }} \
           --set secrets.feedparser.avatureFeedPassword=${{ secrets.avature-feed-password }} \
           --set alertSecrets.slackWebhookUrl=${{ secrets.alert-slack-webhook-url }} \
-          --set configmap.servername=${{ secrets.kube-namespace }}.apps.live.cloud-platform.service.justice.gov.uk \
           --set configmap.envtype=${{ vars.ENV_TYPE }} \
           --set configmap.sentrydns=${{ vars.PHP_DSN }} \
           --set ingress.metadata.annotations.setidentifier=hale-platform-ingress-${{ secrets.kube-namespace }}-green \
-          --set domain=${{ secrets.kube-namespace }}.apps.live.cloud-platform.service.justice.gov.uk \
+          --set domain=${{ vars.ENV_TYPE }}.websitebuilder.service.justice.gov.uk \
           --set nginx.image.repository=754256621582.dkr.ecr.eu-west-2.amazonaws.com/${{ secrets.ecr-repo }}:hale-platform_nginx-${{ github.sha }} \
           --set wp.image.repository=754256621582.dkr.ecr.eu-west-2.amazonaws.com/${{ secrets.ecr-repo }}:hale-platform_wordpress-${{ github.sha }}

--- a/helm_deploy/wordpress/templates/ingress.yaml
+++ b/helm_deploy/wordpress/templates/ingress.yaml
@@ -114,6 +114,7 @@ spec:
   tls:
   - hosts:
     - {{ .Values.domain }}
+    secretName: websitebuilder-{{ .Values.configmap.envtype }}-cert
 {{- if eq .Values.configmap.envtype "prod" }}
   {{- range .Values.ingress.hosts }}
   - hosts:


### PR DESCRIPTION
* Changes the infrastructure domain from `hale-platform-{env}.apps.live.cloud-platform.service.justice.gov.uk` to `{env}.websitebuilder.service.justice.gov.uk`
* Removes `--set configmap.servername` from GitAction as we were not even using it. Servername was being set to domain name.

*Note before merging, will require domain rewriting of both staging and prod.