### PR TITLE
Pull in Hale Components waf set cookie commit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "ministryofjustice/cookie-compliance-for-wordpress": "3.4.15",
         "ministryofjustice/feed-importer": "1.1.0",
         "ministryofjustice/hale": "4.16.3",
-        "ministryofjustice/hale-components": "1.3.2",
+        "ministryofjustice/hale-components": "1.4.0",
         "ministryofjustice/hale-dash": "1.1.7",
         "ministryofjustice/hale-showcase": "1.1.10",
         "ministryofjustice/imbmembers": "dev-main",


### PR DESCRIPTION
Adds the code in Hale Components that sets the WB_CONFIG cookie to manage WAF.