### PR TITLE
Update wp s3 uploads

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "ministryofjustice/ppo": "dev-main",
         "ministryofjustice/wp-gov-uk-notify": "*",
         "ministryofjustice/wp-moj-blocks": "3.14.0",
-        "ministryofjustice/wp-s3-uploads": "dev-main",
+        "ministryofjustice/wp-s3-uploads": "1.0.0",
         "oscarotero/env": "^1.0",
         "php": ">=7.4",
         "relevanssi/relevanssi-premium": "*",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,8 @@ services:
 
   mariadb:
     container_name: mariadb
-#    image: mariadb:10.7.1-focal
-    image: mariadb:11.1.2-jammy
+    image: mariadb:10.11
+#    image: mariadb:11.1.2-jammy
     ports:
       - 3306:3306
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,6 @@ services:
   mariadb:
     container_name: mariadb
     image: mariadb:10.11
-#    image: mariadb:11.1.2-jammy
     ports:
       - 3306:3306
     environment:


### PR DESCRIPTION
* Add the new changes to our uploads plugin 
* Add versioning to our uploads plugin. Started at 1.0 as it is already in prod.
* Fixed to a stable Mariadb version for local dev. 