### PR TITLE
Add WWW subdomain for ICRIR

### DIFF
--- a/helm_deploy/wordpress/values.yaml
+++ b/helm_deploy/wordpress/values.yaml
@@ -301,6 +301,8 @@ ingress:
       certName: iapdc-www-cert
     - name: www.iapdeathsincustody.independent.gov.uk
       certName: iapdci-www-cert
+    - name: www.icrir.independent-inquiry.uk
+      certName: icrir-www-cert
     - name: www.imb.org.uk
       certName: imb-www-cert
     - name: www.justiceinspectorates.gov.uk


### PR DESCRIPTION
Stakeholder reported issue with www.icrir.independent-inquiry.uk redirection. Missing subdomain is now added per this commit should fix the issue.