### PR TITLE
Tweak pod HPA. Set max prod to 12 from 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ dev/themes/*
 !dev/plugins/.gitkeep
 !dev/themes/.gitkeep
 
+# AI
+.claude/

--- a/helm_deploy/wordpress/values.yaml
+++ b/helm_deploy/wordpress/values.yaml
@@ -98,14 +98,14 @@ autoscaling:
   targetMemory: 75
   replicaCount:
     prod:
-      min: 5
-      max: 8
+      min: 6
+      max: 12
     staging:
       min: 2
-      max: 6
+      max: 4
     demo:
       min: 2
-      max: 6
+      max: 4
     dev:
       min: 1
       max: 1
@@ -114,7 +114,7 @@ autoscaling:
 ## Default settings when HPA is not turned on
 ##
 replicaCount:
-  prod: 4
+  prod: 6
   staging: 3
   dev: 1
   demo: 2


### PR DESCRIPTION
Increased max prod pod count to 12 from 8 to give a bit more headroom as we seem to be reaching the 8 threshold quite frequently. 

I've also upded the default to 6min pods. Just easier to work out that it is half of max and gives us a bit more room

Reduced pods in other environments as I don't think they need higher but will monitor.