### PR TITLE
Fix wordpress restart on deploy and multiple `config.sh` runs on local.

### DIFF
--- a/helm_deploy/wordpress/templates/deployment.yaml
+++ b/helm_deploy/wordpress/templates/deployment.yaml
@@ -22,6 +22,8 @@ spec:
         app: wordpress
         tier: frontend-c
     spec:
+      securityContext:
+        fsGroup: 1002
       terminationGracePeriodSeconds: 35
       serviceAccountName: hale-platform-{{ .Values.configmap.envtype }}-service
       containers:
@@ -42,7 +44,7 @@ spec:
             - containerPort: {{ .Values.wp.image.ports.containerPort }}
           volumeMounts:
             - name: wordpress-volume-file-mount
-              mountPath: /var/www/html
+              mountPath: /var/www
             - name: hale-php-config
               mountPath: /usr/local/etc/php/conf.custom
           envFrom:
@@ -91,7 +93,7 @@ spec:
             - containerPort: {{ .Values.nginx.image.ports.containerPort }}
           volumeMounts:
             - name: wordpress-volume-file-mount
-              mountPath: /var/www/html
+              mountPath: /var/www
           {{- if or (eq .Values.configmap.envtype "prod") (eq .Values.configmap.envtype "staging") }}
           readinessProbe:
             exec:

--- a/helm_deploy/wordpress/templates/deployment.yaml
+++ b/helm_deploy/wordpress/templates/deployment.yaml
@@ -22,8 +22,6 @@ spec:
         app: wordpress
         tier: frontend-c
     spec:
-      securityContext:
-        fsGroup: 1002
       terminationGracePeriodSeconds: 35
       serviceAccountName: hale-platform-{{ .Values.configmap.envtype }}-service
       containers:
@@ -44,7 +42,7 @@ spec:
             - containerPort: {{ .Values.wp.image.ports.containerPort }}
           volumeMounts:
             - name: wordpress-volume-file-mount
-              mountPath: /var/www
+              mountPath: /var/www/html
             - name: hale-php-config
               mountPath: /usr/local/etc/php/conf.custom
           envFrom:
@@ -93,7 +91,7 @@ spec:
             - containerPort: {{ .Values.nginx.image.ports.containerPort }}
           volumeMounts:
             - name: wordpress-volume-file-mount
-              mountPath: /var/www
+              mountPath: /var/www/html
           {{- if or (eq .Values.configmap.envtype "prod") (eq .Values.configmap.envtype "staging") }}
           readinessProbe:
             exec:

--- a/opt/scripts/hale-entrypoint.sh
+++ b/opt/scripts/hale-entrypoint.sh
@@ -2,9 +2,31 @@
 set -e
 #set -o xtrace # Uncomment this line for debugging purposes
 
-# Inject shell script into docker-entrypoint so that our own config script can run
+# Make a copy of docker-entrypoint and inject shell script into it so that our own config script can run
 sed "$ i /usr/local/bin/config.sh" /usr/local/bin/docker-entrypoint.sh > /tmp/docker-entrypoint.sh
-cat /tmp/docker-entrypoint.sh > /usr/local/bin/docker-entrypoint.sh
 
-# Execute the modified docker-entrypoint.sh
-/usr/local/bin/docker-entrypoint.sh "php-fpm"
+# WordPress's default docker-entrypoint.sh copies source code from /usr/src/wordpress to
+# /var/www/html using tar. On K8s, /var/www/html is an emptyDir volume owned by root, and
+# the container runs as non-root (UID 1002). When tar extracts, it tries to chmod the mount
+# point directory "." to rwxrwxrwx, which fails with:
+#   tar: .: Cannot change mode to rwxrwxrwx: Operation not permitted
+# This causes the WordPress pod to error and restart once every time a pod is created.
+# The files themselves extract fine — only the chmod on "." fails — so it is safe to ignore.
+# This modification suppresses that specific tar error while still failing on any unexpected
+# tar errors, preventing the unnecessary pod restart.
+#
+# Step 1: Replace the tar pipeline with an error-capturing version
+sed -i 's/tar "${sourceTarArgs\[@\]}" \. | tar "${targetTarArgs\[@\]}"/tar_err=$(tar "${sourceTarArgs[@]}" . | tar "${targetTarArgs[@]}" 2>\&1 || true)/' /tmp/docker-entrypoint.sh
+# Step 2: Insert error checking lines after the tar_err assignment
+sed -i '/tar_err=$(tar.*sourceTarArgs/a\
+filtered=$(echo "$tar_err" | grep -v "Cannot change mode" | grep -v "Exiting with failure" || true)\
+if [ -n "$filtered" ]; then echo "$filtered" >\&2; exit 1; fi' /tmp/docker-entrypoint.sh
+# Step 3: Verify the tar patch was applied — if WordPress changes their entrypoint, we need to know
+if ! grep -q 'tar_err=' /tmp/docker-entrypoint.sh; then
+    echo >&2 "WARNING: tar permission patch was not applied to docker-entrypoint.sh — WordPress base image may have changed"
+fi
+
+# Execute the modified entrypoint from /tmp — deliberately NOT writing back to
+# /usr/local/bin/ so the original stays pristine across container stop/start cycles.
+chmod +x /tmp/docker-entrypoint.sh
+/tmp/docker-entrypoint.sh "php-fpm"

--- a/opt/scripts/hale-entrypoint.sh
+++ b/opt/scripts/hale-entrypoint.sh
@@ -5,27 +5,6 @@ set -e
 # Make a copy of docker-entrypoint and inject shell script into it so that our own config script can run
 sed "$ i /usr/local/bin/config.sh" /usr/local/bin/docker-entrypoint.sh > /tmp/docker-entrypoint.sh
 
-# WordPress's default docker-entrypoint.sh copies source code from /usr/src/wordpress to
-# /var/www/html using tar. On K8s, /var/www/html is an emptyDir volume owned by root, and
-# the container runs as non-root (UID 1002). When tar extracts, it tries to chmod the mount
-# point directory "." to rwxrwxrwx, which fails with:
-#   tar: .: Cannot change mode to rwxrwxrwx: Operation not permitted
-# This causes the WordPress pod to error and restart once every time a pod is created.
-# The files themselves extract fine — only the chmod on "." fails — so it is safe to ignore.
-# This modification suppresses that specific tar error while still failing on any unexpected
-# tar errors, preventing the unnecessary pod restart.
-#
-# Step 1: Replace the tar pipeline with an error-capturing version
-sed -i 's/tar "${sourceTarArgs\[@\]}" \. | tar "${targetTarArgs\[@\]}"/tar_err=$(tar "${sourceTarArgs[@]}" . | tar "${targetTarArgs[@]}" 2>\&1 || true)/' /tmp/docker-entrypoint.sh
-# Step 2: Insert error checking lines after the tar_err assignment
-sed -i '/tar_err=$(tar.*sourceTarArgs/a\
-filtered=$(echo "$tar_err" | grep -v "Cannot change mode" | grep -v "Exiting with failure" || true)\
-if [ -n "$filtered" ]; then echo "$filtered" >\&2; exit 1; fi' /tmp/docker-entrypoint.sh
-# Step 3: Verify the tar patch was applied — if WordPress changes their entrypoint, we need to know
-if ! grep -q 'tar_err=' /tmp/docker-entrypoint.sh; then
-    echo >&2 "WARNING: tar permission patch was not applied to docker-entrypoint.sh — WordPress base image may have changed"
-fi
-
 # Execute the modified entrypoint from /tmp — deliberately NOT writing back to
 # /usr/local/bin/ so the original stays pristine across container stop/start cycles.
 chmod +x /tmp/docker-entrypoint.sh

--- a/opt/scripts/hale-entrypoint.sh
+++ b/opt/scripts/hale-entrypoint.sh
@@ -29,4 +29,4 @@ fi
 # Execute the modified entrypoint from /tmp — deliberately NOT writing back to
 # /usr/local/bin/ so the original stays pristine across container stop/start cycles.
 chmod +x /tmp/docker-entrypoint.sh
-exec /tmp/docker-entrypoint.sh "$@"
+exec /tmp/docker-entrypoint.sh "php-fpm"

--- a/opt/scripts/hale-entrypoint.sh
+++ b/opt/scripts/hale-entrypoint.sh
@@ -5,6 +5,27 @@ set -e
 # Make a copy of docker-entrypoint and inject shell script into it so that our own config script can run
 sed "$ i /usr/local/bin/config.sh" /usr/local/bin/docker-entrypoint.sh > /tmp/docker-entrypoint.sh
 
+# WordPress's default docker-entrypoint.sh copies source code from /usr/src/wordpress to
+# /var/www/html using tar. On K8s, /var/www/html is an emptyDir volume owned by root, and
+# the container runs as non-root (UID 1002). When tar extracts, it tries to chmod the mount
+# point directory "." to rwxrwxrwx, which fails with:
+#   tar: .: Cannot change mode to rwxrwxrwx: Operation not permitted
+# This causes the WordPress pod to error and restart once every time a pod is created.
+# The files themselves extract fine — only the chmod on "." fails — so it is safe to ignore.
+# This modification suppresses that specific tar error while still failing on any unexpected
+# tar errors, preventing the unnecessary pod restart.
+#
+# Step 1: Replace the tar pipeline with an error-capturing version
+sed -i 's/tar "${sourceTarArgs\[@\]}" \. | tar "${targetTarArgs\[@\]}"/tar_err=$(tar "${sourceTarArgs[@]}" . | tar "${targetTarArgs[@]}" 2>\&1 || true)/' /tmp/docker-entrypoint.sh
+# Step 2: Insert error checking lines after the tar_err assignment
+sed -i '/tar_err=$(tar.*sourceTarArgs/a\
+filtered=$(echo "$tar_err" | grep -v "Cannot change mode" | grep -v "Exiting with failure" || true)\
+if [ -n "$filtered" ]; then echo "$filtered" >\&2; exit 1; fi' /tmp/docker-entrypoint.sh
+# Step 3: Verify the tar patch was applied — if WordPress changes their entrypoint, we need to know
+if ! grep -q 'tar_err=' /tmp/docker-entrypoint.sh; then
+    echo >&2 "WARNING: tar permission patch was not applied to docker-entrypoint.sh — WordPress base image may have changed"
+fi
+
 # Execute the modified entrypoint from /tmp — deliberately NOT writing back to
 # /usr/local/bin/ so the original stays pristine across container stop/start cycles.
 chmod +x /tmp/docker-entrypoint.sh

--- a/opt/scripts/hale-entrypoint.sh
+++ b/opt/scripts/hale-entrypoint.sh
@@ -29,4 +29,4 @@ fi
 # Execute the modified entrypoint from /tmp — deliberately NOT writing back to
 # /usr/local/bin/ so the original stays pristine across container stop/start cycles.
 chmod +x /tmp/docker-entrypoint.sh
-/tmp/docker-entrypoint.sh "php-fpm"
+exec /tmp/docker-entrypoint.sh "$@"

--- a/opt/scripts/hale-entrypoint.sh
+++ b/opt/scripts/hale-entrypoint.sh
@@ -5,26 +5,10 @@ set -e
 # Make a copy of docker-entrypoint and inject shell script into it so that our own config script can run
 sed "$ i /usr/local/bin/config.sh" /usr/local/bin/docker-entrypoint.sh > /tmp/docker-entrypoint.sh
 
-# WordPress's default docker-entrypoint.sh copies source code from /usr/src/wordpress to
-# /var/www/html using tar. On K8s, /var/www/html is an emptyDir volume owned by root, and
-# the container runs as non-root (UID 1002). When tar extracts, it tries to chmod the mount
-# point directory "." to rwxrwxrwx, which fails with:
-#   tar: .: Cannot change mode to rwxrwxrwx: Operation not permitted
-# This causes the WordPress pod to error and restart once every time a pod is created.
-# The files themselves extract fine — only the chmod on "." fails — so it is safe to ignore.
-# This modification suppresses that specific tar error while still failing on any unexpected
-# tar errors, preventing the unnecessary pod restart.
-#
-# Step 1: Replace the tar pipeline with an error-capturing version
-sed -i 's/tar "${sourceTarArgs\[@\]}" \. | tar "${targetTarArgs\[@\]}"/tar_err=$(tar "${sourceTarArgs[@]}" . | tar "${targetTarArgs[@]}" 2>\&1 || true)/' /tmp/docker-entrypoint.sh
-# Step 2: Insert error checking lines after the tar_err assignment
-sed -i '/tar_err=$(tar.*sourceTarArgs/a\
-filtered=$(echo "$tar_err" | grep -v "Cannot change mode" | grep -v "Exiting with failure" || true)\
-if [ -n "$filtered" ]; then echo "$filtered" >\&2; exit 1; fi' /tmp/docker-entrypoint.sh
-# Step 3: Verify the tar patch was applied — if WordPress changes their entrypoint, we need to know
-if ! grep -q 'tar_err=' /tmp/docker-entrypoint.sh; then
-    echo >&2 "WARNING: tar permission patch was not applied to docker-entrypoint.sh — WordPress base image may have changed"
-fi
+# Patch the copied entrypoint to suppress a known-harmless tar chmod failure
+# on the /var/www/html mount point that otherwise causes an unnecessary pod
+# restart on every fresh start. See startup-patch.sh for full details.
+/usr/local/bin/startup-patch.sh /tmp/docker-entrypoint.sh
 
 # Execute the modified entrypoint from /tmp — deliberately NOT writing back to
 # /usr/local/bin/ so the original stays pristine across container stop/start cycles.

--- a/opt/scripts/startup-patch.sh
+++ b/opt/scripts/startup-patch.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+#
+# Patch WordPress's docker-entrypoint.sh in place to suppress a known-harmless
+# tar chmod failure that otherwise causes the WordPress pod to error and
+# restart once on every fresh start.
+#
+# Background:
+# WordPress's default docker-entrypoint.sh copies source code from /usr/src/wordpress
+# to /var/www/html using tar. On K8s, /var/www/html is an emptyDir volume owned by
+# root, and the container runs as non-root (UID 1002). When tar extracts, it tries
+# to chmod the mount point directory "." to rwxrwxrwx, which fails with:
+#   tar: .: Cannot change mode to rwxrwxrwx: Operation not permitted
+# The files themselves extract fine — only the chmod on "." fails — so it is safe
+# to ignore. This patch suppresses that specific tar error while still failing on
+# any unexpected tar errors, preventing the unnecessary pod restart.
+#
+# Usage: startup-patch.sh <path-to-docker-entrypoint.sh>
+
+set -e
+
+target_file="${1:?usage: startup-patch.sh <path-to-docker-entrypoint.sh>}"
+
+# The replacement pipeline:
+#   - `{ ...; } 2>&1` groups the pipeline so stderr from BOTH tars is captured
+#     into $tar_err (not just the target side). Upstream already sets
+#     `set -Eeuo pipefail` at the top of docker-entrypoint.sh, so pipefail is
+#     in effect for this pipeline and a source-tar failure will surface in $?.
+#   - `|| tar_status=$?` captures a non-zero pipeline status instead of masking
+#     it with `|| true`, so unknown failures can still fail startup.
+IFS= read -r -d '' tar_pipeline_patch <<'PATCH' || true
+		tar_status=0
+		tar_err=$({ tar "${sourceTarArgs[@]}" . | tar "${targetTarArgs[@]}"; } 2>&1) || tar_status=$?
+PATCH
+
+# Fail startup if either:
+#   - stderr contains anything other than the known-ignorable mount-point chmod
+#     message (and tar's trailing "Exiting with failure" summary), or
+#   - the pipeline exited non-zero but produced no stderr we can inspect
+#     (a silent failure we shouldn't swallow).
+#
+# The ignorable lines are matched precisely so chmod failures against real
+# extracted files (e.g. "tar: ./wp-admin/foo: Cannot change mode ...") still
+# surface and fail the startup instead of being silently filtered out.
+IFS= read -r -d '' tar_error_check <<'PATCH' || true
+		filtered=$(echo "$tar_err" \
+			| grep -vE '^tar: \.: Cannot change mode to [rwx-]{9}: Operation not permitted$' \
+			| grep -vxF 'tar: Exiting with failure status due to previous errors' \
+			|| true)
+		if [ -n "$filtered" ] || { [ "$tar_status" -ne 0 ] && [ -z "$tar_err" ]; }; then
+			echo "${tar_err:-tar failed with status $tar_status}" >&2
+			exit 1
+		fi
+PATCH
+
+# The exact line in WordPress's docker-entrypoint.sh we are replacing.
+tar_pipeline_original='tar "${sourceTarArgs[@]}" . | tar "${targetTarArgs[@]}"'
+
+# Replace the original tar pipeline with our patched version + error check.
+# awk is used instead of sed because it handles multi-line replacements cleanly
+# and has no magic characters (`&`, delimiters) to escape in the replacement text.
+awk -v target="$tar_pipeline_original" \
+    -v replacement="$tar_pipeline_patch"$'\n'"$tar_error_check" '
+    index($0, target) { print replacement; next }
+    { print }
+' "$target_file" > "$target_file.new" \
+    && mv "$target_file.new" "$target_file"
+
+# Verify the tar patch was applied — if WordPress changes their entrypoint, we need to know
+if ! grep -q 'tar_err=' "$target_file"; then
+    echo >&2 "WARNING: tar permission patch was not applied to $target_file — WordPress base image may have changed"
+fi

--- a/wordpress.dockerfile
+++ b/wordpress.dockerfile
@@ -51,7 +51,6 @@ RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 # Create new user to run the container as non-root
 RUN adduser --disabled-password hale -u 1002 \
     && chown -R hale:hale /var/www/html \
-    && chown -R hale:hale /usr/src/wordpress \
     && chown hale:hale /usr/local/bin/docker-entrypoint.sh
 
 # Make multisite scripts executable

--- a/wordpress.dockerfile
+++ b/wordpress.dockerfile
@@ -34,6 +34,7 @@ COPY opt/php/wp-cron-multisite.php /usr/src/wordpress/wp-cron-multisite.php
 # Setup WordPress multisite and network
 COPY opt/scripts/hale-entrypoint.sh /usr/local/bin/
 COPY opt/scripts/config.sh /usr/local/bin/
+COPY opt/scripts/startup-patch.sh /usr/local/bin/
 
 # Generated Composer and NPM compiled artifacts (plugins, themes, CSS, JS)
 # The WP offical Docker image expects files to be in /usr/src/wordpress
@@ -50,11 +51,13 @@ RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 # Create new user to run the container as non-root
 RUN adduser --disabled-password hale -u 1002 \
     && chown -R hale:hale /var/www/html \
+    && chown -R hale:hale /usr/src/wordpress \
     && chown hale:hale /usr/local/bin/docker-entrypoint.sh
 
 # Make multisite scripts executable
 RUN chmod +x /usr/local/bin/hale-entrypoint.sh \
-    && chmod +x /usr/local/bin/config.sh
+    && chmod +x /usr/local/bin/config.sh \
+    && chmod +x /usr/local/bin/startup-patch.sh
 
 # Create the uploads folder
 RUN mkdir -p /usr/src/wordpress/wp-content/uploads

--- a/wordpress.local.dockerfile
+++ b/wordpress.local.dockerfile
@@ -34,6 +34,7 @@ COPY opt/php/wp-cron-multisite.php /usr/src/wordpress/wp-cron-multisite.php
 # Setup WordPress multisite and network
 COPY opt/scripts/hale-entrypoint.sh /usr/local/bin/
 COPY opt/scripts/config.sh /usr/local/bin/
+COPY opt/scripts/startup-patch.sh /usr/local/bin/
 
 # Generated Composer and NPM compiled artifacts (plugins, themes, CSS, JS)
 # The WP offical Docker image expects files to be in /usr/src/wordpress
@@ -54,7 +55,8 @@ RUN adduser --disabled-password hale -u 1002 \
 
 # Make multisite scripts executable
 RUN chmod +x /usr/local/bin/hale-entrypoint.sh \
-    && chmod +x /usr/local/bin/config.sh
+    && chmod +x /usr/local/bin/config.sh \
+    && chmod +x /usr/local/bin/startup-patch.sh
 
 # Create the uploads folder
 RUN mkdir -p /usr/src/wordpress/wp-content/uploads


### PR DESCRIPTION
This PR addresses 2 issues:

### Local config issue

Locally, when running:
  - `docker compose up` then `ctrl + c` then `docker compose up`
  -  `docker compose restart`

It was seen that the `config.sh` script would run multiple times in a row. After each restart cycle, it would run one more time.

This is because we were appending the line  `/usr/local/bin/config.sh` to the file `/usr/local/bin/docker-entrypoint.sh` multiple times.

```
/usr/local/bin/config.sh
/usr/local/bin/config.sh   ← 2nd restart
/usr/local/bin/config.sh   ← 3rd restart
exec "$@"
```

The proposed fix, is to not edit `/usr/local/bin/docker-entrypoint.sh`, but make a copy to `/tmp/docker-entrypoint.sh` then make it executable and run it.

This can be seen in the first and last code block of `hale-entrypoint.sh`

### Pod create, container restart issue

There is an issue where, when a pod is created, the wordpress container will do a single restart and then run as normal.

This restart is caused by a the wordpress default entrypoint script failing. It fails in a very specific and consistent way on every first start. What happens is:

- the script copies the source code `/usr/src/wordpress` to `/var/www/html`
- correctly sets permissions on files and folders **within** `/var/www/html`
- BUT, it attempts and fails to modify the permissions of `/var/www/html`

the failure happens because `/var/www/html` is a Kubernetes file mount, owned by root. And the wordpress user doesn't have permissions to modify it's owner.

See line [28 to 68](https://github.com/docker-library/wordpress/blob/31966261dc850cff923f3d364a484c6476ae8da9/docker-entrypoint.sh#L28) for the code that does this.

The proposed fix is to:
- catch all errors during the file copy process
- specifically allow the `Cannot change mode` error
- ~~Move the mount path up a level from `/var/www/html` to `/var/www`~~
   ~~With that change, the docker entrypoint can modify the permissions of `/var/www/html` without issue.~~

---

This patch has been applied to the dev branch and it is working ok.