### PR TITLE
Swap nginx out for OpenResty - initial Redis request scoring

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -57,6 +57,8 @@ jobs:
       s3-uploads-bucket-url: ${{ secrets.S3_UPLOADS_BUCKET_URL }}
       s3-uploads-object-acl: ${{ secrets.S3_UPLOADS_OBJECT_ACL }}
       cloudfront-distribution-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+      redis-auth: ${{ secrets.REDIS_AUTH }}
+      redis-host: ${{ secrets.REDIS_HOST }}
       alert-slack-webhook-url: ${{ secrets.ALERT_SLACK_WEBHOOK_URL }}
       wb-config: ${{ secrets.WB_CONFIG}}
 
@@ -105,6 +107,8 @@ jobs:
       s3-uploads-bucket-url: ${{ secrets.S3_UPLOADS_BUCKET_URL }}
       s3-uploads-object-acl: ${{ secrets.S3_UPLOADS_OBJECT_ACL }}
       cloudfront-distribution-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+      redis-auth: ${{ secrets.REDIS_AUTH }}
+      redis-host: ${{ secrets.REDIS_HOST }}
       alert-slack-webhook-url: ${{ secrets.ALERT_SLACK_WEBHOOK_URL }}
       wb-config: ${{ secrets.WB_CONFIG}}
 
@@ -153,6 +157,8 @@ jobs:
       s3-uploads-bucket-url: ${{ secrets.S3_UPLOADS_BUCKET_URL }}
       s3-uploads-object-acl: ${{ secrets.S3_UPLOADS_OBJECT_ACL }}
       cloudfront-distribution-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+      redis-auth: ${{ secrets.REDIS_AUTH }}
+      redis-host: ${{ secrets.REDIS_HOST }}
       alert-slack-webhook-url: ${{ secrets.ALERT_SLACK_WEBHOOK_URL }}
       wb-config: ${{ secrets.WB_CONFIG}}
 
@@ -202,5 +208,7 @@ jobs:
       s3-uploads-bucket-url: ${{ secrets.S3_UPLOADS_BUCKET_URL }}
       s3-uploads-object-acl: ${{ secrets.S3_UPLOADS_OBJECT_ACL }}
       cloudfront-distribution-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+      redis-auth: ${{ secrets.REDIS_AUTH }}
+      redis-host: ${{ secrets.REDIS_HOST }}
       alert-slack-webhook-url: ${{ secrets.ALERT_SLACK_WEBHOOK_URL }}
       wb-config: ${{ secrets.WB_CONFIG}}

--- a/.github/workflows/rw-build-image.yaml
+++ b/.github/workflows/rw-build-image.yaml
@@ -87,6 +87,10 @@ on:
         required: true
       auth0-env-domain:
         required: true
+      redis-auth:
+        required: true
+      redis-host:
+        required: true
 
 jobs:
   buildImage:
@@ -265,6 +269,8 @@ jobs:
           --set secrets.auth0envdomain=${{ secrets.auth0-env-domain }} \
           --set secrets.wbconfig=${{ secrets.wb-config }} \
           --set secrets.acftoken=${{ secrets.acf-token }} \
+          --set secrets.redisauth=${{ secrets.redis-auth }} \
+          --set secrets.redishost=${{ secrets.redis-host }} \
           --set alertSecrets.slackWebhookUrl=${{ secrets.alert-slack-webhook-url }} \
           --set configmap.envtype=${{ vars.ENV_TYPE }} \
           --set configmap.sentrydns=${{ vars.PHP_DSN }} \

--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,7 @@
     "composer/installers": "^v2.0",
     "ministryofjustice/cookie-compliance": "1.1.0",
     "ministryofjustice/govwind": "dev-main",
-    "ministryofjustice/hale": "4.31.1",
+    "ministryofjustice/hale": "4.33.0",
     "ministryofjustice/hale-components": "dev-user-cleanup-cron",
     "ministryofjustice/hale-dash": "1.1.8",
     "ministryofjustice/hale-showcase": "1.1.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e2fdc1071d8b3edae638b5218a604d44",
+    "content-hash": "840fd172c2c17101bdda6d6b986f016b",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -983,25 +983,25 @@
         },
         {
             "name": "ministryofjustice/hale",
-            "version": "4.31.1",
+            "version": "4.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ministryofjustice/hale.git",
-                "reference": "1b12b6193faca8266900cdcd890086cf0994a44a"
+                "reference": "0179c92fbcf6e0a1387a7b698f44562f21589416"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ministryofjustice/hale/zipball/1b12b6193faca8266900cdcd890086cf0994a44a",
-                "reference": "1b12b6193faca8266900cdcd890086cf0994a44a",
+                "url": "https://api.github.com/repos/ministryofjustice/hale/zipball/0179c92fbcf6e0a1387a7b698f44562f21589416",
+                "reference": "0179c92fbcf6e0a1387a7b698f44562f21589416",
                 "shasum": ""
             },
             "type": "wordpress-theme",
             "description": "Hale theme",
             "support": {
-                "source": "https://github.com/ministryofjustice/hale/tree/4.31.1",
+                "source": "https://github.com/ministryofjustice/hale/tree/4.33.0",
                 "issues": "https://github.com/ministryofjustice/hale/issues"
             },
-            "time": "2026-02-24T16:50:33+00:00"
+            "time": "2026-04-14T13:24:26+00:00"
         },
         {
             "name": "ministryofjustice/hale-components",
@@ -3619,5 +3619,5 @@
         "php": ">=8.0"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,9 @@ services:
     volumes:
       - ./wordpress:/var/www/html:delegated
       - ./dev:/mnt/dev:delegated
-      - ./opt/nginx/nginx.conf:/etc/nginx/nginx.conf
-      - ./opt/nginx/localwordpress.conf:/etc/nginx/conf.d/localwordpress.conf
+      - ./opt/nginx/nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf
+      - ./opt/nginx/localwordpress.conf:/usr/local/openresty/nginx/conf/conf.d/localwordpress.conf
+      - ./opt/scripts/firewall.lua:/usr/local/openresty/nginx/lua/firewall.lua
       - ./bin/certs:/etc/nginx/certs/self-signed/
     depends_on:
       - wordpress
@@ -20,6 +21,8 @@ services:
     environment:
       VIRTUAL_HOST: hale.docker
       VIRTUAL_PORT: 443
+      FIREWALL_ENABLED: ${FIREWALL_ENABLED:-false}
+      REDIS_SSL: "false"
   mariadb:
     container_name: mariadb
     platform: linux/arm64
@@ -67,10 +70,17 @@ services:
       S3_UPLOADS_BUCKET_URL: ""
       S3_UPLOADS_OBJECT_ACL: ""
       CLOUDFRONT_DISTRIBUTION_ID: ""
+      AUTH0_ENV_CLIENT_ID: ""
+      AUTH0_ENV_CLIENT_SECRET: ""
+      AUTH0_ENV_DOMAIN: ""
       SERVER_NAME: "hale.docker"
       PHP_DSN: "" # Sentry constant (not used locally)
       WP_SENTRY_ENV: ""
       ACF_PRO_LICENSE: ""
+  redis:
+    image: redis:7-alpine
+    profiles:
+    - firewall
 volumes:
   database:
     driver: local

--- a/helm_deploy/wordpress/templates/configmap.yaml
+++ b/helm_deploy/wordpress/templates/configmap.yaml
@@ -8,3 +8,12 @@ data:
   ENV_TYPE: {{ .Values.configmap.envtype }}
   S3_UPLOADS_USE_INSTANCE_PROFILE: {{ .Values.configmap.s3useprofile | quote }}
   PHP_DSN: {{ .Values.configmap.sentrydns }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hale-nginx-config-{{ .Release.Revision }}
+data:
+  FIREWALL_ENABLED: {{ .Values.configmap.firewall.enabled | quote }}
+  FIREWALL_BLOCK_THRESHOLD: {{ .Values.configmap.firewall.blockthreshold | quote }}
+  FIREWALL_SCORE_TTL: {{ .Values.configmap.firewall.scorettl | quote }}

--- a/helm_deploy/wordpress/templates/cron-wp-multisite.yaml
+++ b/helm_deploy/wordpress/templates/cron-wp-multisite.yaml
@@ -17,9 +17,9 @@ spec:
           - name: wp-k8s-cron
             image: {{ .Values.nginx.image.repository }}
             imagePullPolicy: IfNotPresent
+            command: ["/bin/sh", "-c"]
             args:
-            - curl
-            - {{ .Values.domain }}/wp-cron-multisite.php
+            - "curl -sf -H 'Host: {{ .Values.domain }}' http://wordpress:8080/wp-cron-multisite.php"
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:

--- a/helm_deploy/wordpress/templates/deployment.yaml
+++ b/helm_deploy/wordpress/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
             - containerPort: {{ .Values.wp.image.ports.containerPort }}
           volumeMounts:
             - name: wordpress-volume-file-mount
-              mountPath: /var/www/html
+              mountPath: /var/www
             - name: hale-php-config
               mountPath: /usr/local/etc/php/conf.custom
           envFrom:
@@ -91,7 +91,12 @@ spec:
             - containerPort: {{ .Values.nginx.image.ports.containerPort }}
           volumeMounts:
             - name: wordpress-volume-file-mount
-              mountPath: /var/www/html
+              mountPath: /var/www
+          envFrom:
+            - configMapRef:
+                name: hale-nginx-config-{{ .Release.Revision }}
+            - secretRef:
+                name: hale-nginx-secrets-{{ .Release.Revision }}
           {{- if or (eq .Values.configmap.envtype "prod") (eq .Values.configmap.envtype "staging") }}
           readinessProbe:
             exec:

--- a/helm_deploy/wordpress/templates/secrets.yaml
+++ b/helm_deploy/wordpress/templates/secrets.yaml
@@ -30,5 +30,14 @@ stringData:
   AUTH0_ENV_CLIENT_SECRET: {{ .Values.secrets.auth0envclientsecret }}
   AUTH0_ENV_DOMAIN: {{ .Values.secrets.auth0envdomain }}
   ACF_PRO_LICENSE: {{ .Values.secrets.acftoken }}
+---
+apiVersion: v1
+kind: Secret
+metadata: 
+  name: hale-nginx-secrets-{{ .Release.Revision }} 
+type: Opaque
+stringData:
+  REDIS_AUTH: {{ .Values.secrets.redisauth }}
+  REDIS_HOST: {{ .Values.secrets.redishost }}
 {{- end }}
 

--- a/helm_deploy/wordpress/values.yaml
+++ b/helm_deploy/wordpress/values.yaml
@@ -145,7 +145,7 @@ configmap:
   firewall:
     enabled: "true"   # Enable the lua firewall module
     blockthreshold: 0 # Monitor mode - log scores, but never block an IP
-    scorettl: 60.     # Reset an IPs score after 60 seconds of inactivity
+    scorettl: 60      # Reset an IPs score after 60 seconds of inactivity
 
 
 ## @param secrets passed in via GitActions

--- a/helm_deploy/wordpress/values.yaml
+++ b/helm_deploy/wordpress/values.yaml
@@ -143,9 +143,9 @@ configmap:
   s3useprofile: "true"
   sentrydns: ""
   firewall:
-    enabled: "true"
-    blockthreshold: 0
-    scorettl: 60
+    enabled: "true"   # Enable the lua firewall module
+    blockthreshold: 0 # Monitor mode - log scores, but never block an IP
+    scorettl: 60.     # Reset an IPs score after 60 seconds of inactivity
 
 
 ## @param secrets passed in via GitActions

--- a/helm_deploy/wordpress/values.yaml
+++ b/helm_deploy/wordpress/values.yaml
@@ -142,6 +142,11 @@ configmap:
   envtype: ""
   s3useprofile: "true"
   sentrydns: ""
+  firewall:
+    enabled: "true"
+    blockthreshold: 0
+    scorettl: 60
+
 
 ## @param secrets passed in via GitActions
 ##
@@ -172,6 +177,8 @@ secrets:
   auth0envclientsecret: ""
   auth0envdomain: ""
   acftoken: ""
+  redisauth: ""
+  redishost: ""
 
 ## @param Toggle alerts on/off
 ##

--- a/makefile
+++ b/makefile
@@ -26,10 +26,18 @@ run:
 	@./bin/upload.sh
 	@echo "✓ Site is running"
 
+# Run site (start redis and enable firewall) using Docker
+run-with-firewall:
+	@echo "Starting Docker containers..."
+	FIREWALL_ENABLED=true docker compose --profile firewall up -d
+	@chmod +x bin/upload.sh
+	@./bin/upload.sh
+	@echo "✓ Site is running"
+
 # Shutdown site using Docker
 down:
 	@echo "Stopping Docker containers..."
-	docker compose down --remove-orphans
+	docker compose --profile firewall down --remove-orphans
 	@echo "✓ Containers stopped"
 
 # Build all images on local machine

--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -1,6 +1,32 @@
-FROM --platform=linux/amd64 nginxinc/nginx-unprivileged:latest
+FROM openresty/openresty:alpine
 
-# Extend NGINX configurations to support WordPress Multisite
-# and apply our own custom configurations
-COPY opt/nginx/nginx.conf /etc/nginx/
-COPY opt/nginx/wordpress.conf /etc/nginx/conf.d/
+# Install additional Alpine packages
+RUN apk update && apk add curl
+
+# Create non-root user (UID/GID 1002 to match org standard)
+RUN addgroup -g 1002 -S hale \
+    && adduser -u 1002 -D -S -G hale -h /var/cache/nginx hale
+
+# Create required directories with correct ownership
+RUN mkdir -p /usr/local/openresty/nginx/logs \
+    && mkdir -p /usr/local/openresty/nginx/client_body_temp \
+    && mkdir -p /usr/local/openresty/nginx/proxy_temp \
+    && mkdir -p /usr/local/openresty/nginx/fastcgi_temp \
+    && mkdir -p /usr/local/openresty/nginx/uwsgi_temp \
+    && mkdir -p /usr/local/openresty/nginx/scgi_temp \
+    && mkdir -p /usr/local/openresty/nginx/cache \
+    && chown -R hale:hale /usr/local/openresty/nginx
+
+# Copy configuration, Lua module and error pages
+COPY opt/nginx/nginx.conf          /usr/local/openresty/nginx/conf/nginx.conf
+COPY opt/nginx/wordpress.conf      /usr/local/openresty/nginx/conf/conf.d/
+COPY opt/scripts/firewall.lua      /usr/local/openresty/nginx/lua/firewall.lua
+COPY opt/nginx/error-pages/        /usr/local/openresty/nginx/html/error-pages/
+
+# Switch to non-root user (must use numeric UID for K8s runAsNonRoot verification)
+USER 1002
+
+EXPOSE 8080
+
+# Start in the foreground
+CMD ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]

--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -1,7 +1,7 @@
 FROM openresty/openresty:alpine
 
 # Install additional Alpine packages
-RUN apk update && apk add curl
+RUN apk update && apk add curl ca-certificates
 
 # Create non-root user (UID/GID 1002 to match org standard)
 RUN addgroup -g 1002 -S hale \

--- a/nginx.local.dockerfile
+++ b/nginx.local.dockerfile
@@ -1,13 +1,32 @@
-FROM arm64v8/nginx:1.25.2
+FROM openresty/openresty:alpine
 
-RUN apt-get -y update
-RUN apt-get -y install vim
+# Install additional Alpine packages
+RUN apk update && apk add curl
 
-# Copy custom NGINX configurations required for WordPress Multisite
-COPY opt/nginx/nginx.conf /etc/nginx/
-COPY opt/nginx/localwordpress.conf /etc/nginx/conf.d/
+# Create non-root user (UID/GID 1002 to match org standard)
+RUN addgroup -g 1002 -S hale \
+    && adduser -u 1002 -D -S -G hale -h /var/cache/nginx hale
 
-RUN rm -r /etc/nginx/conf.d/default.conf
+# Create required directories with correct ownership
+RUN mkdir -p /usr/local/openresty/nginx/logs \
+    && mkdir -p /usr/local/openresty/nginx/client_body_temp \
+    && mkdir -p /usr/local/openresty/nginx/proxy_temp \
+    && mkdir -p /usr/local/openresty/nginx/fastcgi_temp \
+    && mkdir -p /usr/local/openresty/nginx/uwsgi_temp \
+    && mkdir -p /usr/local/openresty/nginx/scgi_temp \
+    && chown -R hale:hale /usr/local/openresty/nginx
+
+# Copy configuration, Lua module and error pages
+COPY opt/nginx/nginx.conf          /usr/local/openresty/nginx/conf/nginx.conf
+COPY opt/nginx/localwordpress.conf /usr/local/openresty/nginx/conf/conf.d/
+COPY opt/scripts/firewall.lua      /usr/local/openresty/nginx/lua/firewall.lua
+COPY opt/nginx/error-pages/        /usr/local/openresty/nginx/html/error-pages/
+
+# Switch to non-root user (numeric UID for consistency with production)
+USER 1002
 
 EXPOSE 443
 EXPOSE 8080
+
+# Start in the foreground
+CMD ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]

--- a/nginx.local.dockerfile
+++ b/nginx.local.dockerfile
@@ -1,7 +1,7 @@
 FROM openresty/openresty:alpine
 
 # Install additional Alpine packages
-RUN apk update && apk add curl
+RUN apk update && apk add curl ca-certificates
 
 # Create non-root user (UID/GID 1002 to match org standard)
 RUN addgroup -g 1002 -S hale \

--- a/opt/nginx/error-pages/error.html
+++ b/opt/nginx/error-pages/error.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Error</title>
+<style>
+body { font-family: Arial, sans-serif; text-align: center; padding: 50px; background: #f5f5f5; color: #333; }
+h1 { font-size: 48px; margin-bottom: 10px; }
+p { font-size: 18px; color: #666; }
+</style>
+</head>
+<body>
+<h1><!--# echo var="status" default="Error" --></h1>
+<p><!--# echo var="status" default="An error occurred" --></p>
+</body>
+</html>

--- a/opt/nginx/localwordpress.conf
+++ b/opt/nginx/localwordpress.conf
@@ -23,9 +23,28 @@ server {
     ssl_certificate_key /etc/nginx/certs/self-signed/hale.docker-key.pem;
     server_name _;
     root /var/www/html;
+
+    # Firewall score variable — set by Lua, included in access log
+    set $firewall_score "-";
+
     # Define the file to load in order within our root dir
     index index.php;
-    
+
+    # Custom error pages — hide OpenResty branding
+    ssi on;
+    error_page 400 401 403 404 405 408 500 502 503 504 /error.html;
+    location = /error.html {
+        root /usr/local/openresty/nginx/html/error-pages;
+        internal;
+    }
+
+    # Firewall stats endpoint (put BEFORE location /)
+    location = /firewall-stats {
+        content_by_lua_block {
+            require("firewall").stats()
+        }
+    }
+
     location ~ ^(/[^/]+)?/files/(.+) {
         try_files /wp-content/blogs.dir/$blogid/files/$2 /wp-includes/ms-files.php?file=$2;
         access_log off;     
@@ -49,6 +68,11 @@ server {
         try_files $uri $uri/ /index.php?$args;
     }
     location ~ \.php$ {
+        # Firewall: check bans, score request
+        access_by_lua_block {
+            require("firewall").req()
+        }
+
         try_files $uri =404;
         include fastcgi_params;
         fastcgi_intercept_errors on;
@@ -58,6 +82,11 @@ server {
         proxy_connect_timeout 1000s;
         proxy_send_timeout 1000s;
         proxy_read_timeout 1000s;
+
+        # Firewall: penalize bad responses
+        log_by_lua_block {
+            require("firewall").res()
+        }
     }
     # Static files - Added CSS, JS, and other web assets
     location ~* ^.+\.(css|js|ogg|ogv|svg|svgz|eot|otf|woff|woff2|mp4|ttf|rss|atom|jpg|jpeg|gif|png|ico|zip|tgz|gz|rar|bz2|doc|xls|exe|ppt|tar|mid|midi|wav|bmp|rtf|webp|map)$ {

--- a/opt/nginx/localwordpress.conf
+++ b/opt/nginx/localwordpress.conf
@@ -31,9 +31,9 @@ server {
     index index.php;
 
     # Custom error pages — hide OpenResty branding
-    ssi on;
     error_page 400 401 403 405 408 500 502 503 504 /error.html;
     location = /error.html {
+        ssi on;
         root /usr/local/openresty/nginx/html/error-pages;
         internal;
     }

--- a/opt/nginx/localwordpress.conf
+++ b/opt/nginx/localwordpress.conf
@@ -32,7 +32,7 @@ server {
 
     # Custom error pages — hide OpenResty branding
     ssi on;
-    error_page 400 401 403 404 405 408 500 502 503 504 /error.html;
+    error_page 400 401 403 405 408 500 502 503 504 /error.html;
     location = /error.html {
         root /usr/local/openresty/nginx/html/error-pages;
         internal;

--- a/opt/nginx/nginx.conf
+++ b/opt/nginx/nginx.conf
@@ -68,6 +68,13 @@ http {
         ssl_protocols TLSv1.2 TLSv1.3; # Dropping SSLv3, ref: POODLE
         ssl_prefer_server_ciphers on;
 
+        # CA bundle used by Lua cosocket SSL connections (e.g. resty.redis to ElastiCache).
+        # Uses the system Mozilla trust store installed via the ca-certificates Alpine package.
+        lua_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
+        # How many levels deep in the certificate chain to verify.
+        # 3 covers: leaf cert → intermediate CA → root CA.
+        lua_ssl_verify_depth        3;
+
         ##
         # Real IP Settings
         ##

--- a/opt/nginx/nginx.conf
+++ b/opt/nginx/nginx.conf
@@ -1,7 +1,36 @@
 worker_processes auto;
 
+# ============================================================================
+# ENVIRONMENT VARIABLE PASSTHROUGH
+# ============================================================================
+# By default, nginx STRIPS all environment variables before spawning worker
+# processes. This means os.getenv() in Lua would return nil for everything.
+#
+# The "env" directive explicitly allows variables so they survive into
+# workers (and therefore into our Lua firewall code).
+#
+# IMPORTANT: You must add an entry here for any env var you want to read
+# with os.getenv() in Lua. Just having it in docker-compose.yml, or in 
+# the Kubernetes deployment is not enough.
+#
+# Reference: https://nginx.org/en/docs/ngx_core_module.html#env
+# ============================================================================
+
+# Redis connection settings
+env REDIS_HOST;
+env REDIS_PORT;
+env REDIS_AUTH;
+env REDIS_SSL;
+env REDIS_POOL_SIZE;
+env REDIS_KEEPALIVE_MS;
+
+# Firewall settings
+env FIREWALL_ENABLED;
+env FIREWALL_BLOCK_THRESHOLD;
+env FIREWALL_SCORE_TTL;
+
 pid /tmp/nginx.pid; # Changed from /var/run/nginx.pid
-error_log  /var/log/nginx/error.log;
+error_log /dev/stderr info;
 
 include /etc/nginx/modules-enabled/*.conf;
 
@@ -18,11 +47,12 @@ http {
         tcp_nopush on;
         types_hash_max_size 2048;
         server_tokens off;
+        more_clear_headers Server;
 
         server_names_hash_bucket_size 64;
         server_name_in_redirect off;
 
-        include /etc/nginx/mime.types;
+        include /usr/local/openresty/nginx/conf/mime.types;
         default_type application/octet-stream;
 
         fastcgi_buffers 16 16k; 
@@ -39,17 +69,46 @@ http {
         ssl_prefer_server_ciphers on;
 
         ##
+        # Real IP Settings
+        ##
+
+        # The K8s nginx ingress strips any client-supplied X-Forwarded-For
+        # and sets it to the true client IP, so XFF is always trusted.
+        # We accept it from all sources (ingress in K8s, Docker bridge locally).
+        real_ip_header X-Forwarded-For;
+        real_ip_recursive on;
+        set_real_ip_from 0.0.0.0/0;
+        set_real_ip_from ::/0;
+
+        ##
+        # DNS Settings
+        ##
+
+        # Required for Lua HTTP clients (e.g., cosocket-based calls).
+        # "local=on" reads nameservers from /etc/resolv.conf, which in Docker
+        # points to Docker's DNS (127.0.0.11) and in K8s to CoreDNS.
+        # This allows Lua code to resolve service names like "redis" or "wordpress".
+        resolver local=on;
+
+        ##
         # Logging Settings
         ##
 
-        #accss_log /var/log/nginx/access.log;
-        error_log /var/log/nginx/error.log;
+        # Access log with firewall score — one clean line per request.
+        # $firewall_score is set by the Lua firewall module in req().
+        log_format main '$remote_addr - $remote_user [$time_local] '
+                        '"$request" $status $body_bytes_sent '
+                        '"$http_referer" "$http_user_agent" '
+                        'fw_score=$firewall_score cache=$upstream_cache_status';
+        access_log /dev/stdout main;
+
+        error_log /dev/stderr info;
 
         ##
         # Gzip Settings
         ##
 
-       gzip on;
+        gzip on;
 
         gzip_vary on;
         gzip_proxied any;
@@ -61,7 +120,19 @@ http {
         ##
         # Virtual Host Configs
         ##
+        include /usr/local/openresty/nginx/conf/conf.d/*.conf;
+      
+        ##
+        # Lua module path
+        ##
 
-        include /etc/nginx/conf.d/*.conf;
-        include /etc/nginx/sites-enabled/*;
+        lua_package_path "/usr/local/openresty/nginx/lua/?.lua;;";
+
+        ##
+        # Firewall startup — logs resolved config once per worker
+        ##
+
+        init_worker_by_lua_block {
+            require("firewall").init()
+        }
 }

--- a/opt/nginx/wordpress.conf
+++ b/opt/nginx/wordpress.conf
@@ -28,10 +28,10 @@ server {
     index index.php;
 
     # Custom error pages — hide OpenResty branding
-    ssi on;
     error_page 400 401 403 405 408 500 502 503 504 /error.html;
     location = /error.html {
         root /usr/local/openresty/nginx/html/error-pages;
+        ssi on;
         internal;
     }
     

--- a/opt/nginx/wordpress.conf
+++ b/opt/nginx/wordpress.conf
@@ -29,7 +29,7 @@ server {
 
     # Custom error pages — hide OpenResty branding
     ssi on;
-    error_page 400 401 403 404 405 408 500 502 503 504 /error.html;
+    error_page 400 401 403 405 408 500 502 503 504 /error.html;
     location = /error.html {
         root /usr/local/openresty/nginx/html/error-pages;
         internal;

--- a/opt/nginx/wordpress.conf
+++ b/opt/nginx/wordpress.conf
@@ -11,7 +11,7 @@ map $blogname $blogid{
     #include /var/www/wordpress/wp-content/plugins/nginx-helper/map.conf ;
 }
 # FastCGI Cache config
-fastcgi_cache_path /etc/nginx/cache levels=1:2 keys_zone=WPCACHE:100m inactive=60m;
+fastcgi_cache_path /usr/local/openresty/nginx/cache levels=1:2 keys_zone=WPCACHE:100m inactive=60m;
 fastcgi_cache_key "$scheme$request_method$host$request_uri";
 fastcgi_cache_use_stale error timeout invalid_header http_500;
 fastcgi_ignore_headers Cache-Control Expires Set-Cookie;
@@ -21,8 +21,19 @@ server {
     server_name _;
     root /var/www/html;
 
+    # Firewall score variable — set by Lua, included in access log
+    set $firewall_score "-";
+
     # Define the file to load in order within our root dir
     index index.php;
+
+    # Custom error pages — hide OpenResty branding
+    ssi on;
+    error_page 400 401 403 404 405 408 500 502 503 504 /error.html;
+    location = /error.html {
+        root /usr/local/openresty/nginx/html/error-pages;
+        internal;
+    }
     
     # FastCGI request buffering
     fastcgi_request_buffering off;
@@ -67,6 +78,11 @@ server {
         try_files $uri $uri/ /index.php?$args;
     }
     location ~ \.php$ {
+        # Firewall: check bans, score request
+        access_by_lua_block {
+            require("firewall").req()
+        }
+
         include fastcgi_params;
         fastcgi_buffers 16 16k;
         fastcgi_buffer_size 32k;
@@ -80,6 +96,11 @@ server {
         fastcgi_cache_valid 200 60m;
         fastcgi_read_timeout 600;
         add_header X-FastCGI-Cache $upstream_cache_status;
+
+        # Firewall: penalize bad responses
+        log_by_lua_block {
+            require("firewall").res()
+        }
     }
     # Activate once nginx purge module has been installed
     #location ~ /purge(/.*) {
@@ -106,9 +127,9 @@ server {
     location = /robots.txt { access_log off; log_not_found off; }
     # Security
     location ^~ /wp-login.php {
-       # Block access to default login without invoking PHP
+        # Block access to default login without invoking PHP
         deny all;
-      }
+    }
     location = /xmlrpc.php {
         deny all;
     }

--- a/opt/php/www.local.conf
+++ b/opt/php/www.local.conf
@@ -1,0 +1,449 @@
+; Start a new pool named 'www'.
+; the variable $pool can be used in any directive and will be replaced by the
+; pool name ('www' here)
+[www]
+
+; Per pool prefix
+; It only applies on the following directives:
+; - 'access.log'
+; - 'slowlog'
+; - 'listen' (unixsocket)
+; - 'chroot'
+; - 'chdir'
+; - 'php_values'
+; - 'php_admin_values'
+; When not set, the global prefix (or NONE) applies instead.
+; Note: This directive can also be relative to the global prefix.
+; Default Value: none
+;prefix = /path/to/pools/$pool
+
+; Unix user/group of processes
+; Note: The user is mandatory. If the group is not set, the default user's group
+;       will be used.
+; ****These are ignored and off as they won't run when we are running the container as non-root.
+;user = hale
+;group = hale
+
+; The address on which to accept FastCGI requests.
+; Valid syntaxes are:
+;   'ip.add.re.ss:port'    - to listen on a TCP socket to a specific IPv4 address on
+;                            a specific port;
+;   '[ip:6:addr:ess]:port' - to listen on a TCP socket to a specific IPv6 address on
+;                            a specific port;
+;   'port'                 - to listen on a TCP socket to all addresses
+;                            (IPv6 and IPv4-mapped) on a specific port;
+;   '/path/to/unix/socket' - to listen on a unix socket.
+; Note: This value is mandatory.
+listen = 9000
+
+; Set listen(2) backlog.
+; Default Value: 511 (-1 on FreeBSD and OpenBSD)
+;listen.backlog = 511
+
+; Set permissions for unix socket, if one is used. In Linux, read/write
+; permissions must be set in order to allow connections from a web server. Many
+; BSD-derived systems allow connections regardless of permissions. The owner
+; and group can be specified either by name or by their numeric IDs.
+; Default Values: user and group are set as the running user
+;                 mode is set to 0660
+;listen.owner = www-data
+;listen.group = www-data
+;listen.mode = 0660
+; When POSIX Access Control Lists are supported you can set them using
+; these options, value is a comma separated list of user/group names.
+; When set, listen.owner and listen.group are ignored
+;listen.acl_users =
+;listen.acl_groups =
+
+; List of addresses (IPv4/IPv6) of FastCGI clients which are allowed to connect.
+; Equivalent to the FCGI_WEB_SERVER_ADDRS environment variable in the original
+; PHP FCGI (5.2.2+). Makes sense only with a tcp listening socket. Each address
+; must be separated by a comma. If this value is left blank, connections will be
+; accepted from any ip address.
+; Default Value: any
+;listen.allowed_clients = 127.0.0.1
+
+; Specify the nice(2) priority to apply to the pool processes (only if set)
+; The value can vary from -19 (highest priority) to 20 (lower priority)
+; Note: - It will only work if the FPM master process is launched as root
+;       - The pool processes will inherit the master process priority
+;         unless it specified otherwise
+; Default Value: no set
+; process.priority = -19
+
+; Set the process dumpable flag (PR_SET_DUMPABLE prctl) even if the process user
+; or group is differrent than the master process user. It allows to create process
+; core dump and ptrace the process for the pool user.
+; Default Value: no
+; process.dumpable = yes
+
+; Choose how the process manager will control the number of child processes.
+; Possible Values:
+;   static  - a fixed number (pm.max_children) of child processes;
+;   dynamic - the number of child processes are set dynamically based on the
+;             following directives. With this process management, there will be
+;             always at least 1 children.
+;             pm.max_children      - the maximum number of children that can
+;                                    be alive at the same time.
+;             pm.start_servers     - the number of children created on startup.
+;             pm.min_spare_servers - the minimum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is less than this
+;                                    number then some children will be created.
+;             pm.max_spare_servers - the maximum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is greater than this
+;                                    number then some children will be killed.
+;  ondemand - no children are created at startup. Children will be forked when
+;             new requests will connect. The following parameter are used:
+;             pm.max_children           - the maximum number of children that
+;                                         can be alive at the same time.
+;             pm.process_idle_timeout   - The number of seconds after which
+;                                         an idle process will be killed.
+ ; Note: This value is mandatory.
+pm = dynamic
+
+; The number of child processes to be created when pm is set to 'static' and the
+; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.
+; This value sets the limit on the number of simultaneous requests that will be
+; served. Equivalent to the ApacheMaxClients directive with mpm_prefork.
+; Equivalent to the PHP_FCGI_CHILDREN environment variable in the original PHP
+; CGI. The below defaults are based on a server without much resources. Don't
+; forget to tweak pm.* to fit your needs.
+; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
+; Note: This value is mandatory.
+pm.max_children = 10
+
+; The number of child processes created on startup.
+; Note: Used only when pm is set to 'dynamic'
+; Default Value: (min_spare_servers + max_spare_servers) / 2
+pm.start_servers = 4
+
+; The desired minimum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.min_spare_servers = 2
+
+; The desired maximum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.max_spare_servers = 5
+
+; The number of seconds after which an idle process will be killed.
+; Note: Used only when pm is set to 'ondemand'
+; Default Value: 10s
+;pm.process_idle_timeout = 10s;
+
+; The number of requests each child process should execute before respawning.
+; This can be useful to work around memory leaks in 3rd party libraries. For
+; endless request processing specify '0'. Equivalent to PHP_FCGI_MAX_REQUESTS.
+; Default Value: 0
+pm.max_requests = 500
+
+; The URI to view the FPM status page. If this value is not set, no URI will be
+; recognized as a status page. It shows the following informations:
+;   pool                 - the name of the pool;
+;   process manager      - static, dynamic or ondemand;
+;   start time           - the date and time FPM has started;
+;   start since          - number of seconds since FPM has started;
+;   accepted conn        - the number of request accepted by the pool;
+;   listen queue         - the number of request in the queue of pending
+;                          connections (see backlog in listen(2));
+;   max listen queue     - the maximum number of requests in the queue
+;                          of pending connections since FPM has started;
+;   listen queue len     - the size of the socket queue of pending connections;
+;   idle processes       - the number of idle processes;
+;   active processes     - the number of active processes;
+;   total processes      - the number of idle + active processes;
+;   max active processes - the maximum number of active processes since FPM
+;                          has started;
+;   max children reached - number of times, the process limit has been reached,
+;                          when pm tries to start more children (works only for
+;                          pm 'dynamic' and 'ondemand');
+; Value are updated in real time.
+; Example output:
+;   pool:                 www
+;   process manager:      static
+;   start time:           01/Jul/2011:17:53:49 +0200
+;   start since:          62636
+;   accepted conn:        190460
+;   listen queue:         0
+;   max listen queue:     1
+;   listen queue len:     42
+;   idle processes:       4
+;   active processes:     11
+;   total processes:      15
+;   max active processes: 12
+;   max children reached: 0
+;
+; By default the status page output is formatted as text/plain. Passing either
+; 'html', 'xml' or 'json' in the query string will return the corresponding
+; output syntax. Example:
+;   http://www.foo.bar/status
+;   http://www.foo.bar/status?json
+;   http://www.foo.bar/status?html
+;   http://www.foo.bar/status?xml
+;
+; By default the status page only outputs short status. Passing 'full' in the
+; query string will also return status for each pool process.
+; Example:
+;   http://www.foo.bar/status?full
+;   http://www.foo.bar/status?json&full
+;   http://www.foo.bar/status?html&full
+;   http://www.foo.bar/status?xml&full
+; The Full status returns for each process:
+;   pid                  - the PID of the process;
+;   state                - the state of the process (Idle, Running, ...);
+;   start time           - the date and time the process has started;
+;   start since          - the number of seconds since the process has started;
+;   requests             - the number of requests the process has served;
+;   request duration     - the duration in µs of the requests;
+;   request method       - the request method (GET, POST, ...);
+;   request URI          - the request URI with the query string;
+;   content length       - the content length of the request (only with POST);
+;   user                 - the user (PHP_AUTH_USER) (or '-' if not set);
+;   script               - the main script called (or '-' if not set);
+;   last request cpu     - the %cpu the last request consumed
+;                          it's always 0 if the process is not in Idle state
+;                          because CPU calculation is done when the request
+;                          processing has terminated;
+;   last request memory  - the max amount of memory the last request consumed
+;                          it's always 0 if the process is not in Idle state
+;                          because memory calculation is done when the request
+;                          processing has terminated;
+; If the process is in Idle state, then informations are related to the
+; last request the process has served. Otherwise informations are related to
+; the current request being served.
+; Example output:
+;   ************************
+;   pid:                  31330
+;   state:                Running
+;   start time:           01/Jul/2011:17:53:49 +0200
+;   start since:          63087
+;   requests:             12808
+;   request duration:     1250261
+;   request method:       GET
+;   request URI:          /test_mem.php?N=10000
+;   content length:       0
+;   user:                 -
+;   script:               /home/fat/web/docs/php/test_mem.php
+;   last request cpu:     0.00
+;   last request memory:  0
+;
+; Note: There is a real-time FPM status monitoring sample web page available
+;       It's available in: /usr/local/share/php/fpm/status.html
+;
+; Note: The value must start with a leading slash (/). The value can be
+;       anything, but it may not be a good idea to use the .php extension or it
+;       may conflict with a real PHP file.
+; Default Value: not set
+;pm.status_path = /status
+
+; The ping URI to call the monitoring page of FPM. If this value is not set, no
+; URI will be recognized as a ping page. This could be used to test from outside
+; that FPM is alive and responding, or to
+; - create a graph of FPM availability (rrd or such);
+; - remove a server from a group if it is not responding (load balancing);
+; - trigger alerts for the operating team (24/7).
+; Note: The value must start with a leading slash (/). The value can be
+;       anything, but it may not be a good idea to use the .php extension or it
+;       may conflict with a real PHP file.
+; Default Value: not set
+;ping.path = /ping
+
+; This directive may be used to customize the response of a ping request. The
+; response is formatted as text/plain with a 200 response code.
+; Default Value: pong
+;ping.response = pong
+
+; The access log file
+; Default: not set
+;access.log = log/$pool.access.log
+
+; The access log format.
+; The following syntax is allowed
+;  %%: the '%' character
+;  %C: %CPU used by the request
+;      it can accept the following format:
+;      - %{user}C for user CPU only
+;      - %{system}C for system CPU only
+;      - %{total}C  for user + system CPU (default)
+;  %d: time taken to serve the request
+;      it can accept the following format:
+;      - %{seconds}d (default)
+;      - %{miliseconds}d
+;      - %{mili}d
+;      - %{microseconds}d
+;      - %{micro}d
+;  %e: an environment variable (same as $_ENV or $_SERVER)
+;      it must be associated with embraces to specify the name of the env
+;      variable. Some exemples:
+;      - server specifics like: %{REQUEST_METHOD}e or %{SERVER_PROTOCOL}e
+;      - HTTP headers like: %{HTTP_HOST}e or %{HTTP_USER_AGENT}e
+;  %f: script filename
+;  %l: content-length of the request (for POST request only)
+;  %m: request method
+;  %M: peak of memory allocated by PHP
+;      it can accept the following format:
+;      - %{bytes}M (default)
+;      - %{kilobytes}M
+;      - %{kilo}M
+;      - %{megabytes}M
+;      - %{mega}M
+;  %n: pool name
+;  %o: output header
+;      it must be associated with embraces to specify the name of the header:
+;      - %{Content-Type}o
+;      - %{X-Powered-By}o
+;      - %{Transfert-Encoding}o
+;      - ....
+;  %p: PID of the child that serviced the request
+;  %P: PID of the parent of the child that serviced the request
+;  %q: the query string
+;  %Q: the '?' character if query string exists
+;  %r: the request URI (without the query string, see %q and %Q)
+;  %R: remote IP address
+;  %s: status (response code)
+;  %t: server time the request was received
+;      it can accept a strftime(3) format:
+;      %d/%b/%Y:%H:%M:%S %z (default)
+;      The strftime(3) format must be encapsuled in a %{<strftime_format>}t tag
+;      e.g. for a ISO8601 formatted timestring, use: %{%Y-%m-%dT%H:%M:%S%z}t
+;  %T: time the log has been written (the request has finished)
+;      it can accept a strftime(3) format:
+;      %d/%b/%Y:%H:%M:%S %z (default)
+;      The strftime(3) format must be encapsuled in a %{<strftime_format>}t tag
+;      e.g. for a ISO8601 formatted timestring, use: %{%Y-%m-%dT%H:%M:%S%z}t
+;  %u: remote user
+;
+; Default: "%R - %u %t \"%m %r\" %s"
+;access.format = "%R - %u %t \"%m %r%Q%q\" %s %f %{mili}d %{kilo}M %C%%"
+
+; The log file for slow requests
+; Default Value: not set
+; Note: slowlog is mandatory if request_slowlog_timeout is set
+;slowlog = log/$pool.log.slow
+
+; The timeout for serving a single request after which a PHP backtrace will be
+; dumped to the 'slowlog' file. A value of '0s' means 'off'.
+; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
+; Default Value: 0
+;request_slowlog_timeout = 0
+
+; Depth of slow log stack trace.
+; Default Value: 20
+;request_slowlog_trace_depth = 20
+
+; The timeout for serving a single request after which the worker process will
+; be killed. This option should be used when the 'max_execution_time' ini option
+; does not stop script execution for some reason. A value of '0' means 'off'.
+; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
+; Default Value: 0
+request_terminate_timeout = 600
+
+; The timeout set by 'request_terminate_timeout' ini option is not engaged after
+; application calls 'fastcgi_finish_request' or when application has finished and
+; shutdown functions are being called (registered via register_shutdown_function).
+; This option will enable timeout limit to be applied unconditionally
+; even in such cases.
+; Default Value: no
+;request_terminate_timeout_track_finished = no
+
+; Set open file descriptor rlimit.
+; Default Value: system defined value
+;rlimit_files = 1024
+
+; Set max core size rlimit.
+; Possible Values: 'unlimited' or an integer greater or equal to 0
+; Default Value: system defined value
+;rlimit_core = 0
+
+; Chroot to this directory at the start. This value must be defined as an
+; absolute path. When this value is not set, chroot is not used.
+; Note: you can prefix with '$prefix' to chroot to the pool prefix or one
+; of its subdirectories. If the pool prefix is not set, the global prefix
+; will be used instead.
+; Note: chrooting is a great security feature and should be used whenever
+;       possible. However, all PHP paths will be relative to the chroot
+;       (error_log, sessions.save_path, ...).
+; Default Value: not set
+;chroot =
+
+; Chdir to this directory at the start.
+; Note: relative path can be used.
+; Default Value: current directory or / when chroot
+;chdir = /var/www
+
+; Redirect worker stdout and stderr into main error log. If not set, stdout and
+; stderr will be redirected to /dev/null according to FastCGI specs.
+; Note: on highloaded environement, this can cause some delay in the page
+; process time (several ms).
+; Default Value: no
+;catch_workers_output = yes
+
+; Decorate worker output with prefix and suffix containing information about
+; the child that writes to the log and if stdout or stderr is used as well as
+; log level and time. This options is used only if catch_workers_output is yes.
+; Settings to "no" will output data as written to the stdout or stderr.
+; Default value: yes
+;decorate_workers_output = no
+
+; Clear environment in FPM workers
+; Prevents arbitrary environment variables from reaching FPM worker processes
+; by clearing the environment in workers before env vars specified in this
+; pool configuration are added.
+; Setting to "no" will make all environment variables available to PHP code
+; via getenv(), $_ENV and $_SERVER.
+; Default Value: yes
+;clear_env = no
+
+; Limits the extensions of the main script FPM will allow to parse. This can
+; prevent configuration mistakes on the web server side. You should only limit
+; FPM to .php extensions to prevent malicious users to use other extensions to
+; execute php code.
+; Note: set an empty value to allow all extensions.
+; Default Value: .php
+;security.limit_extensions = .php .php3 .php4 .php5 .php7
+
+; Pass environment variables like LD_LIBRARY_PATH. All $VARIABLEs are taken from
+; the current environment.
+; Default Value: clean env
+;env[HOSTNAME] = $HOSTNAME
+;env[PATH] = /usr/local/bin:/usr/bin:/bin
+;env[TMP] = /tmp
+;env[TMPDIR] = /tmp
+;env[TEMP] = /tmp
+
+; Additional php.ini defines, specific to this pool of workers. These settings
+; overwrite the values previously defined in the php.ini. The directives are the
+; same as the PHP SAPI:
+;   php_value/php_flag             - you can set classic ini defines which can
+;                                    be overwritten from PHP call 'ini_set'.
+;   php_admin_value/php_admin_flag - these directives won't be overwritten by
+;                                     PHP call 'ini_set'
+; For php_*flag, valid values are on, off, 1, 0, true, false, yes or no.
+
+; Defining 'extension' will load the corresponding shared extension from
+; extension_dir. Defining 'disable_functions' or 'disable_classes' will not
+; overwrite previously defined php.ini values, but will append the new value
+; instead.
+
+; Note: path INI options can be relative and will be expanded with the prefix
+; (pool, global or /usr/local)
+
+; Default Value: nothing is defined by default except the values in php.ini and
+;                specified at startup with the -d argument
+;php_admin_value[sendmail_path] = /usr/sbin/sendmail -t -i -f www@my.domain.com
+php_flag[display_errors] = off
+php_admin_value[error_log] = /var/log/error_log
+php_admin_value[error_reporting] = E_ALL & ~E_NOTICE & ~E_WARNING & ~E_STRICT
+;& ~E_DEPRECATED
+php_admin_flag[log_errors] = on
+;php_admin_value[memory_limit] = 32M
+
+; File upload settings for 400MB files
+php_admin_value[upload_max_filesize] = 400M
+php_admin_value[post_max_size] = 512M
+php_admin_value[max_execution_time] = 600
+php_admin_value[max_input_time] = 600
+php_admin_value[memory_limit] = 512M

--- a/opt/scripts/firewall.lua
+++ b/opt/scripts/firewall.lua
@@ -194,10 +194,9 @@ function _M.req()
     if not FIREWALL_ENABLED then return end
 
     -- Get the client's IP address.
-    -- nginx's realip module resolves X-Forwarded-For into a single, clean IP
-    -- (configured via real_ip_header + set_real_ip_from in nginx.conf).
-    -- Falls back to remote_addr if realip is not available (e.g. direct connection).
-    local ip = ngx.var.realip_remote_addr or ngx.var.remote_addr
+    -- nginx's realip module rewrites remote_addr to the client IP from X-Forwarded-For.
+    -- realip_remote_addr holds the original connection IP (the proxy).
+    local ip = ngx.var.remote_addr
     
     -- pcall = "protected call" - Lua's try/catch equivalent.
     -- It calls the function and catches any errors instead of crashing.

--- a/opt/scripts/firewall.lua
+++ b/opt/scripts/firewall.lua
@@ -366,25 +366,29 @@ function _M.stats()
         return
     end
     
-    -- KEYS * returns all keys in Redis. 
-    -- WARNING: This is slow on large datasets - fine for debugging only!
-    local keys = red:keys("*")
-    
-    -- Check if keys is nil (error) or empty table.
+    -- SCAN is non-blocking: unlike KEYS it yields between batches so Redis
+    -- stays responsive. We do a single pass (no cursor loop) capped at 500
+    -- entries, scoped to score:* keys only.
+    -- SCAN returns: { cursor, { key, key, ... } }
+    local res = red:scan("0", "MATCH", "score:*", "COUNT", 500)
+
+    -- Check for error or empty result.
     -- #keys is the length operator - returns number of elements in array.
+    local keys = res and res[2]
     if not keys or #keys == 0 then
         ngx.say("(empty database)")
         release_redis(red)
         return
     end
-    
-    -- Loop through all keys and print their values.
+
+    -- Loop through returned keys and print their values.
     -- ipairs() iterates over array-style tables in order.
     -- The underscore "_" is a Lua convention for "I don't need this value"
     -- (ipairs returns index, value - we only need value).
+    ngx.say("showing up to 500 entries (single SCAN pass)")
     for _, key in ipairs(keys) do
         local val = red:get(key)
-        
+
         -- ngx.null is a special value that resty.redis returns for nil Redis values.
         -- It's different from Lua's nil for technical reasons.
         if val and val ~= ngx.null then

--- a/opt/scripts/firewall.lua
+++ b/opt/scripts/firewall.lua
@@ -1,0 +1,394 @@
+-- ============================================================================
+-- FIREWALL STUB MODULE
+-- ============================================================================
+-- Simple implementation for testing. Increments score:{ip} on each
+-- request and 404 response. Includes basic banning logic.
+--
+-- USAGE:
+--   In nginx.conf, set:
+--     access_by_lua_block { require("firewall").req() }
+--     log_by_lua_block { require("firewall").res() }
+--     content_by_lua_block { require("firewall").stats() }
+--
+-- LUA QUICK REFERENCE FOR THIS FILE:
+--   - Comments start with -- (double dash)
+--   - "local" restricts scope to this file (like "private" in other languages)
+--   - Tables {} are Lua's only data structure (used as arrays AND objects)
+--   - Strings concatenate with .. (two dots), e.g., "hello" .. "world"
+--   - nil is Lua's null/undefined
+--   - "and" / "or" are logical operators (not && / ||)
+--   - Functions can return multiple values: local ok, err = some_func()
+--   - #table gives the length of an array-style table
+--
+-- OPENRESTY CONCEPTS:
+--   - This runs inside nginx via OpenResty (nginx + LuaJIT)
+--   - "ngx" is a global object provided by OpenResty for nginx interaction
+--   - ngx.var.* accesses nginx variables (request headers, IP, etc.)
+--   - ngx.log() writes to nginx error log
+--   - ngx.say() writes to HTTP response body
+--   - resty.redis is OpenResty's non-blocking Redis client
+-- ============================================================================
+
+
+-- ============================================================================
+-- MODULE TABLE
+-- ============================================================================
+-- In Lua, modules are just tables. We create an empty table "_M" and attach
+-- functions to it. At the end of the file, we "return _M" to export it.
+-- When nginx.conf does require("firewall"), it gets this table back.
+-- ============================================================================
+local _M = {}
+
+
+-- ============================================================================
+-- CONFIGURATION
+-- ============================================================================
+-- These variables are declared with "local" so they're private to this file.
+-- os.getenv() reads environment variables; "or" provides a default if nil.
+-- tonumber() converts strings to numbers (env vars are always strings).
+-- ============================================================================
+
+-- Redis server hostname (K8s service name or IP)
+local REDIS_HOST = os.getenv("REDIS_HOST") or "redis"
+
+-- Redis server port (standard Redis port is 6379)
+local REDIS_PORT = tonumber(os.getenv("REDIS_PORT")) or 6379
+
+-- Redis password (nil if not set, which means no auth required)
+local REDIS_AUTH = os.getenv("REDIS_AUTH")
+
+-- Use TLS for Redis connection (default true for ElastiCache, set false for local dev)
+local REDIS_SSL = os.getenv("REDIS_SSL") ~= "false"
+
+-- Timeout in milliseconds for Redis operations (200ms keeps requests fast)
+local REDIS_TIMEOUT = 200
+
+-- Max connections to keep in the pool PER nginx worker process.
+-- With 18 K8s pods, default of 25 means max ~450 connections to Redis.
+-- Tuned for cross-AZ latency (~1ms). Increase if you see pool exhaustion errors.
+local REDIS_POOL_SIZE = tonumber(os.getenv("REDIS_POOL_SIZE")) or 25
+
+-- How long (ms) to keep idle connections in the pool before closing them.
+-- 10 seconds is a good balance between reuse and not hogging connections.
+local REDIS_KEEPALIVE_MS = tonumber(os.getenv("REDIS_KEEPALIVE_MS")) or 10000
+
+-- How long (seconds) before a score:{ip} key expires in Redis.
+-- After 1 hour of no requests, the IP's score resets to 0.
+local SCORE_TTL = tonumber(os.getenv("FIREWALL_SCORE_TTL")) or 3600
+
+-- Kill switch: set to "false" to disable all firewall scoring and blocking.
+-- When disabled, req() and res() return immediately with zero overhead.
+local FIREWALL_ENABLED = os.getenv("FIREWALL_ENABLED") ~= "false"
+
+-- Score threshold above which requests are blocked with 403 Forbidden.
+-- Set to 0 to disable blocking (scoring only).
+local BLOCK_THRESHOLD = tonumber(os.getenv("FIREWALL_BLOCK_THRESHOLD")) or 2000
+
+
+-- ============================================================================
+-- STARTUP HOOK: Called from nginx init_worker_by_lua_block
+-- ============================================================================
+-- This runs once per nginx worker process when nginx starts (or reloads).
+-- We log the resolved firewall settings so operators can verify env config.
+--
+-- In nginx.conf: init_worker_by_lua_block { require("firewall").init() }
+-- ============================================================================
+function _M.init()
+    ngx.log(
+        ngx.NOTICE,
+        "[firewall] startup ENABLED=", tostring(FIREWALL_ENABLED),
+        " BLOCK_THRESHOLD=", BLOCK_THRESHOLD,
+        " SCORE_TTL=", SCORE_TTL,
+        " REDIS_SSL=", tostring(REDIS_SSL)
+    )
+end
+
+
+-- ============================================================================
+-- HELPER: Create and connect a Redis client
+-- ============================================================================
+-- This is a "local function" - only callable within this file (not exported).
+-- Returns a connected Redis client object, or nil if connection failed.
+--
+-- IMPORTANT: We "fail open" - if Redis is down, we return nil and the
+-- calling code allows the request through. This prevents Redis outages
+-- from taking down the whole site.
+-- ============================================================================
+local function connect_redis()
+    -- require() loads a Lua module. "resty.redis" is OpenResty's Redis client.
+    -- Unlike Node.js require(), Lua caches modules so this is cheap after first call.
+    local redis = require "resty.redis"
+    
+    -- Create a new Redis client instance (this doesn't connect yet)
+    local red = redis:new()
+    
+    -- Set timeout for all subsequent Redis operations on this client
+    red:set_timeout(REDIS_TIMEOUT)
+    
+    -- Attempt to connect to Redis server.
+    -- Lua functions often return (success_value, error_message).
+    -- If connect fails, ok=nil and err contains the error string.
+    -- For ElastiCache with encryption-in-transit, we need SSL.
+    local ok, err
+    if REDIS_SSL then
+        -- ssl_verify=false because ElastiCache certs may not be in CA bundle
+        ok, err = red:connect(REDIS_HOST, REDIS_PORT, { ssl = true, ssl_verify = false })
+    else
+        ok, err = red:connect(REDIS_HOST, REDIS_PORT)
+    end
+    if not ok then
+        -- ngx.log writes to nginx error log. ngx.ERR is the severity level.
+        -- Multiple arguments are concatenated automatically.
+        ngx.log(ngx.ERR, "[firewall] redis connect failed (fail-open): ", err)
+        return nil  -- Return nil to signal failure; caller should handle gracefully
+    end
+    
+    -- If REDIS_AUTH is set and not empty string, authenticate with Redis.
+    -- The "and" here is a guard: only evaluate right side if left is truthy.
+    if REDIS_AUTH and REDIS_AUTH ~= "" then
+        -- Note: we reuse variable names "ok" and "err" - this is common in Lua.
+        -- The previous ok/err are just overwritten (no block scoping like JS let).
+        local ok, err = red:auth(REDIS_AUTH)
+        if not ok then
+            ngx.log(ngx.ERR, "[firewall] redis auth failed (fail-open): ", err)
+            return nil
+        end
+    end
+    
+    -- Return the connected client object
+    return red
+end
+
+
+-- ============================================================================
+-- HELPER: Return Redis connection to the pool
+-- ============================================================================
+-- Instead of closing the TCP connection, we return it to a connection pool.
+-- The next request can reuse it, avoiding TCP handshake overhead.
+--
+-- Parameters:
+--   red: The Redis client object (or nil if connection failed)
+--
+-- set_keepalive(timeout_ms, pool_size):
+--   - timeout_ms: Close connection if idle longer than this
+--   - pool_size: Max connections to keep in pool (per nginx worker)
+-- ============================================================================
+local function release_redis(red)
+    -- Guard against nil (if connect_redis failed)
+    if red then
+        red:set_keepalive(REDIS_KEEPALIVE_MS, REDIS_POOL_SIZE)
+    end
+end
+
+
+-- ============================================================================
+-- REQUEST PHASE: Called on every incoming request
+-- ============================================================================
+-- This function is called from nginx.conf in the "access_by_lua" directive,
+-- which runs before nginx processes the request. We increment a counter
+-- for this IP address to track request frequency.
+--
+-- The function is attached to _M (our module table) so it's exported.
+-- In nginx.conf: access_by_lua_block { require("firewall").req() }
+-- ============================================================================
+function _M.req()
+    if not FIREWALL_ENABLED then return end
+
+    -- Get the client's IP address.
+    -- nginx's realip module resolves X-Forwarded-For into a single, clean IP
+    -- (configured via real_ip_header + set_real_ip_from in nginx.conf).
+    -- Falls back to remote_addr if realip is not available (e.g. direct connection).
+    local ip = ngx.var.realip_remote_addr or ngx.var.remote_addr
+    
+    -- pcall = "protected call" - Lua's try/catch equivalent.
+    -- It calls the function and catches any errors instead of crashing.
+    -- Returns: (true, return_value) on success, (false, error_message) on error.
+    -- We wrap Redis operations in pcall so a bug doesn't break the site.
+    local ok, err = pcall(function()
+        -- Get a Redis connection (may return nil if Redis is down)
+        local red = connect_redis()
+        if not red then return end  -- Fail-open: just exit the function, allow request
+        
+        -- Check current score and block if above threshold.
+        -- We check BEFORE incrementing so blocked IPs get rejected immediately.
+        if BLOCK_THRESHOLD > 0 then
+            local score = red:get("score:" .. ip)
+            -- score is nil if key doesn't exist, ngx.null if Redis returns null
+            if score and score ~= ngx.null and tonumber(score) > BLOCK_THRESHOLD then
+                release_redis(red)  -- Return connection before exiting
+                ngx.log(ngx.WARN, "[firewall] blocked ip=", ip, " score=", score)
+                ngx.exit(ngx.HTTP_FORBIDDEN)  -- 403 - stops request processing
+            end
+        end
+        
+        -- Pipeline batches multiple Redis commands into one network round-trip.
+        -- This is faster than sending INCR, waiting, then sending EXPIRE.
+        red:init_pipeline()
+        
+        -- INCR: Increment the counter. Creates key with value 1 if doesn't exist.
+        -- The ".." operator concatenates strings: "score:" .. "1.2.3.4" = "score:1.2.3.4"
+        red:incr("score:" .. ip)
+        
+        -- EXPIRE: Reset the TTL to 1 hour. Key auto-deletes after this time.
+        red:expire("score:" .. ip, SCORE_TTL)
+        
+        -- Send the pipeline to Redis and get results.
+        -- Returns a table (array) with one result per command: {new_score, 1}
+        local results = red:commit_pipeline()
+        
+        -- Store the score in an nginx variable for the access log.
+        -- This avoids noisy per-request error log lines.
+        if results then
+            ngx.var.firewall_score = tostring(results[1])
+        end
+        
+        -- Return connection to pool for reuse
+        release_redis(red)
+    end)
+    
+    -- If pcall caught an error (ok=false), log it but don't block the request
+    if not ok then
+        ngx.log(ngx.ERR, "[firewall] req error (fail-open): ", err)
+    end
+end
+
+
+-- ============================================================================
+-- RESPONSE PHASE: Called after response is sent, for 404s only
+-- ============================================================================
+-- This runs in nginx's "log_by_lua" phase, after the response is sent.
+-- We add extra score for 404 errors, since attackers often probe for
+-- vulnerable URLs which return 404.
+--
+-- IMPORTANT: The log_by_lua phase does NOT allow socket operations (Redis,
+-- HTTP calls, etc.) because the request is already finished. OpenResty
+-- disables these APIs to prevent blocking during logging.
+--
+-- SOLUTION: We use ngx.timer.at(0, callback) to schedule the Redis work
+-- in a separate "timer context" where sockets ARE allowed. The "0" means
+-- "run as soon as possible" (not a delay). The callback runs asynchronously
+-- after this function returns.
+--
+-- In nginx.conf: log_by_lua_block { require("firewall").res() }
+-- ============================================================================
+function _M.res()
+    if not FIREWALL_ENABLED then return end
+
+    -- ngx.status is the HTTP response status code (200, 404, 500, etc.)
+    -- Early return if not a 404 - we only care about "not found" responses
+    if ngx.status ~= 404 then
+        return
+    end
+    
+    -- Capture variables NOW, before the request context disappears.
+    -- Once we're inside the timer callback, ngx.var.* won't be available
+    -- because the original request will be gone.
+    local ip = ngx.var.realip_remote_addr or ngx.var.remote_addr
+    
+    -- Schedule the Redis work to run in a timer context.
+    -- ngx.timer.at(delay, callback) schedules a function to run after 'delay' seconds.
+    -- Using 0 means "run immediately, but in a context where sockets work".
+    --
+    -- The callback receives one argument: 'premature' (boolean).
+    -- premature=true means nginx is shutting down and we should abort quickly.
+    local ok, err = ngx.timer.at(0, function(premature)
+        -- If nginx is shutting down, don't bother with Redis operations
+        if premature then
+            return
+        end
+        
+        -- Now we're in a timer context - sockets are allowed here!
+        -- Wrap in pcall for safety (same pattern as req())
+        local timer_ok, timer_err = pcall(function()
+            local red = connect_redis()
+            if not red then return end  -- Fail-open: Redis down, skip scoring
+            
+            -- Pipeline the INCR + EXPIRE for efficiency
+            red:init_pipeline()
+            red:incr("score:" .. ip)
+            red:expire("score:" .. ip, SCORE_TTL)
+            local results = red:commit_pipeline()
+            
+            if results then
+                ngx.log(ngx.INFO, "[firewall] 404 penalty ip=", ip, " score=", results[1])
+            end
+            
+            release_redis(red)
+        end)
+        
+        if not timer_ok then
+            ngx.log(ngx.ERR, "[firewall] res timer error: ", timer_err)
+        end
+    end)
+    
+    -- If we couldn't even schedule the timer, log it (rare, usually means
+    -- too many pending timers - controlled by lua_max_pending_timers in nginx.conf)
+    if not ok then
+        ngx.log(ngx.ERR, "[firewall] res failed to create timer: ", err)
+    end
+end
+
+
+-- ============================================================================
+-- STATS ENDPOINT: Debug endpoint to view all Redis data
+-- ============================================================================
+-- Returns all keys and values from Redis as plain text.
+-- Useful for debugging but should be protected in production!
+--
+-- In nginx.conf, you'd set up a location block like:
+--   location /firewall-stats {
+--       content_by_lua_block { require("firewall").stats() }
+--   }
+-- ============================================================================
+function _M.stats()
+    -- Set Content-Type to text/plain so browsers display inline instead of
+    -- prompting a file download. Must be set before any ngx.say() calls.
+    ngx.header.content_type = "text/plain"
+    
+    local red = connect_redis()
+    if not red then
+        -- ngx.say() writes to HTTP response body (adds newline automatically)
+        ngx.say("redis error: connection failed")
+        return
+    end
+    
+    -- KEYS * returns all keys in Redis. 
+    -- WARNING: This is slow on large datasets - fine for debugging only!
+    local keys = red:keys("*")
+    
+    -- Check if keys is nil (error) or empty table.
+    -- #keys is the length operator - returns number of elements in array.
+    if not keys or #keys == 0 then
+        ngx.say("(empty database)")
+        release_redis(red)
+        return
+    end
+    
+    -- Loop through all keys and print their values.
+    -- ipairs() iterates over array-style tables in order.
+    -- The underscore "_" is a Lua convention for "I don't need this value"
+    -- (ipairs returns index, value - we only need value).
+    for _, key in ipairs(keys) do
+        local val = red:get(key)
+        
+        -- ngx.null is a special value that resty.redis returns for nil Redis values.
+        -- It's different from Lua's nil for technical reasons.
+        if val and val ~= ngx.null then
+            ngx.say(key, " = ", val)
+        else
+            ngx.say(key, " = (nil)")
+        end
+    end
+    
+    release_redis(red)
+end
+
+
+-- ============================================================================
+-- EXPORT THE MODULE
+-- ============================================================================
+-- This is required! When nginx.conf does require("firewall"), Lua runs this
+-- entire file and returns whatever "return" gives. We return our _M table
+-- which contains the init(), req(), res(), and stats() functions.
+-- ============================================================================
+return _M

--- a/opt/scripts/firewall.lua
+++ b/opt/scripts/firewall.lua
@@ -283,7 +283,11 @@ function _M.res()
     -- Capture variables NOW, before the request context disappears.
     -- Once we're inside the timer callback, ngx.var.* won't be available
     -- because the original request will be gone.
-    local ip = ngx.var.realip_remote_addr or ngx.var.remote_addr
+
+    -- Get the client's IP address.
+    -- nginx's realip module rewrites remote_addr to the client IP from X-Forwarded-For.
+    -- realip_remote_addr holds the original connection IP (the proxy).
+    local ip = ngx.var.remote_addr
     
     -- Schedule the Redis work to run in a timer context.
     -- ngx.timer.at(delay, callback) schedules a function to run after 'delay' seconds.

--- a/opt/scripts/firewall.lua
+++ b/opt/scripts/firewall.lua
@@ -203,6 +203,12 @@ function _M.req()
     -- It calls the function and catches any errors instead of crashing.
     -- Returns: (true, return_value) on success, (false, error_message) on error.
     -- We wrap Redis operations in pcall so a bug doesn't break the site.
+    --
+    -- IMPORTANT: ngx.exit() works via a Lua error internally, so it must NOT
+    -- be called inside pcall — pcall would catch and swallow it, allowing the
+    -- request through. Instead we set a flag inside pcall and call ngx.exit()
+    -- after the protected block.
+    local blocked = false
     local ok, err = pcall(function()
         -- Get a Redis connection (may return nil if Redis is down)
         local red = connect_redis()
@@ -216,7 +222,8 @@ function _M.req()
             if score and score ~= ngx.null and tonumber(score) > BLOCK_THRESHOLD then
                 release_redis(red)  -- Return connection before exiting
                 ngx.log(ngx.WARN, "[firewall] blocked ip=", ip, " score=", score)
-                ngx.exit(ngx.HTTP_FORBIDDEN)  -- 403 - stops request processing
+                blocked = true
+                return  -- Exit the pcall cleanly; ngx.exit() called below
             end
         end
         
@@ -244,7 +251,12 @@ function _M.req()
         -- Return connection to pool for reuse
         release_redis(red)
     end)
-    
+
+    -- Called outside pcall so OpenResty's internal error mechanism works correctly
+    if blocked then
+        ngx.exit(ngx.HTTP_FORBIDDEN)  -- 403 - stops request processing
+    end
+
     -- If pcall caught an error (ok=false), log it but don't block the request
     if not ok then
         ngx.log(ngx.ERR, "[firewall] req error (fail-open): ", err)

--- a/opt/scripts/firewall.lua
+++ b/opt/scripts/firewall.lua
@@ -131,8 +131,7 @@ local function connect_redis()
     -- For ElastiCache with encryption-in-transit, we need SSL.
     local ok, err
     if REDIS_SSL then
-        -- ssl_verify=false because ElastiCache certs may not be in CA bundle
-        ok, err = red:connect(REDIS_HOST, REDIS_PORT, { ssl = true, ssl_verify = false })
+        ok, err = red:connect(REDIS_HOST, REDIS_PORT, { ssl = true, ssl_verify = true })
     else
         ok, err = red:connect(REDIS_HOST, REDIS_PORT)
     end

--- a/opt/scripts/hale-entrypoint.sh
+++ b/opt/scripts/hale-entrypoint.sh
@@ -2,10 +2,9 @@
 set -e
 #set -o xtrace # Uncomment this line for debugging purposes
 
-# Make a copy of docker-entrypoint and inject shell script into it so that our own config script can run
+# Inject shell script into docker-entrypoint so that our own config script can run
 sed "$ i /usr/local/bin/config.sh" /usr/local/bin/docker-entrypoint.sh > /tmp/docker-entrypoint.sh
+cat /tmp/docker-entrypoint.sh > /usr/local/bin/docker-entrypoint.sh
 
-# Execute the modified entrypoint from /tmp — deliberately NOT writing back to
-# /usr/local/bin/ so the original stays pristine across container stop/start cycles.
-chmod +x /tmp/docker-entrypoint.sh
-/tmp/docker-entrypoint.sh "php-fpm"
+# Execute the modified docker-entrypoint.sh
+/usr/local/bin/docker-entrypoint.sh "php-fpm"

--- a/opt/scripts/hale-entrypoint.sh
+++ b/opt/scripts/hale-entrypoint.sh
@@ -2,9 +2,10 @@
 set -e
 #set -o xtrace # Uncomment this line for debugging purposes
 
-# Inject shell script into docker-entrypoint so that our own config script can run
+# Make a copy of docker-entrypoint and inject shell script into it so that our own config script can run
 sed "$ i /usr/local/bin/config.sh" /usr/local/bin/docker-entrypoint.sh > /tmp/docker-entrypoint.sh
-cat /tmp/docker-entrypoint.sh > /usr/local/bin/docker-entrypoint.sh
 
-# Execute the modified docker-entrypoint.sh
-/usr/local/bin/docker-entrypoint.sh "php-fpm"
+# Execute the modified entrypoint from /tmp — deliberately NOT writing back to
+# /usr/local/bin/ so the original stays pristine across container stop/start cycles.
+chmod +x /tmp/docker-entrypoint.sh
+/tmp/docker-entrypoint.sh "php-fpm"

--- a/wordpress.dockerfile
+++ b/wordpress.dockerfile
@@ -50,6 +50,7 @@ RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 # Create new user to run the container as non-root
 RUN adduser --disabled-password hale -u 1002 \
     && chown -R hale:hale /var/www/html \
+    && chown -R hale:hale /usr/src/wordpress \
     && chown hale:hale /usr/local/bin/docker-entrypoint.sh
 
 # Make multisite scripts executable

--- a/wordpress.local.dockerfile
+++ b/wordpress.local.dockerfile
@@ -28,7 +28,7 @@ RUN addgroup -g 1001 wp \
 COPY opt/php/load.php /usr/src/wordpress/wp-content/mu-plugins/load.php
 COPY opt/php/application.php /usr/src/wordpress/wp-content/mu-plugins/application.php
 COPY opt/php/error-handling.php /usr/src/wordpress/error-handling.php
-COPY opt/php/www.conf /usr/local/etc/php-fpm.d/www.conf
+COPY opt/php/www.local.conf /usr/local/etc/php-fpm.d/www.conf
 COPY opt/php/wp-cron-multisite.php /usr/src/wordpress/wp-cron-multisite.php
 
 # Setup WordPress multisite and network


### PR DESCRIPTION
In this PR:

- Swap nginx out for OpenResty
- Lua module with initial Redis request scoring. POC that we can read and write to Redis
- Kubernetes deployment, secrets and configmap updated for REDIS_ and FIREWALL_ config.
- Curl command updated, 1. to work with OpenResty's `command` and 2. to call endpoint within local network.
- Custom error pages, so we don't advertise our server.
- New make command `make run-with-firewall` so we can run locally.