### PR TITLE
Add timeout to cron-wp-multisite.yaml

### DIFF
--- a/helm_deploy/wordpress/templates/cron-wp-multisite.yaml
+++ b/helm_deploy/wordpress/templates/cron-wp-multisite.yaml
@@ -11,6 +11,8 @@ spec:
   failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
+      # Jobs usually complete in ~20s; fail any job still running after 120s.
+      activeDeadlineSeconds: 120
       ttlSecondsAfterFinished: 100
       template:
         spec:


### PR DESCRIPTION
The issue.

We have `concurrencyPolicy: Forbid` so that multiple cron jobs do not overlap. This is important so as to not overload the Cloud Platform resources.

But, it means that if there is an issue (for any reason) where a jobs state is stuck in active. Then the concurrency policy means a new job is not created.

This is what happened recently where a job was stuck in an active state - even though it have an exit code of 0.

Proposed fix.

The proposed fix, is to add a timeout, and mark a job as failed if it is active for longer than 120s. Marking it as failed, means that a new nob can start, and the failed job is eventually cleaned up.