### PR TITLE
Allow requests for zip, doc, xls file extensions to try wordpress

### DIFF
--- a/opt/nginx/localwordpress.conf
+++ b/opt/nginx/localwordpress.conf
@@ -95,7 +95,8 @@ server {
         }
     }
     # Static files - Added CSS, JS, and other web assets
-    location ~* ^.+\.(css|js|ogg|ogv|svg|svgz|eot|otf|woff|woff2|mp4|ttf|rss|atom|jpg|jpeg|gif|png|ico|zip|tgz|gz|rar|bz2|doc|xls|exe|ppt|tar|mid|midi|wav|bmp|rtf|webp|map)$ {
+    # Not included: file types supported by wp-document-revisions plugin (doc, docx, pdf, xls, xlsx zip).
+    location ~* ^.+\.(css|js|ogg|ogv|svg|svgz|eot|otf|woff|woff2|mp4|ttf|rss|atom|jpg|jpeg|gif|png|ico|tgz|gz|rar|bz2|exe|ppt|tar|mid|midi|wav|bmp|rtf|webp|map)$ {
         access_log off; 
         log_not_found off; 
         expires max;

--- a/opt/nginx/wordpress.conf
+++ b/opt/nginx/wordpress.conf
@@ -124,7 +124,8 @@ server {
     }
     
     # Other static files (removed video extensions: ogg, ogv, mp4)
-    location ~* ^.+\.(css|js|svg|svgz|eot|otf|woff|ttf|rss|atom|jpg|jpeg|gif|png|ico|zip|tgz|gz|rar|bz2|doc|xls|exe|ppt|tar|mid|midi|wav|bmp|rtf)$ {
+    # Not included: file types supported by wp-document-revisions plugin (doc, docx, pdf, xls, xlsx zip).
+    location ~* ^.+\.(css|js|svg|svgz|eot|otf|woff|ttf|rss|atom|jpg|jpeg|gif|png|ico|tgz|gz|rar|bz2|exe|ppt|tar|mid|midi|wav|bmp|rtf)$ {
         access_log off; log_not_found off; expires max;
     }
 


### PR DESCRIPTION
Currently /anything.zip will 404 if nginx does not have the file.

This PR allows .zip and other supported file extensions to try wordpress, after nginx's file system.