### PR TITLE
Fix wp-document-revisions upload path on S3 environments

### DIFF
--- a/opt/php/wpdr-document-upload-dir.php
+++ b/opt/php/wpdr-document-upload-dir.php
@@ -6,17 +6,22 @@
  * file paths resolve via the s3:// stream wrapper instead of a stale local
  * basedir cached in wpdr's constructor before s3-uploads filters upload_dir.
  *
- * Only active when s3-uploads is in play (i.e. non-local environments, matching
- * the gate in mu-plugins/load.php).
+ * Only active when s3-uploads is in play (non-local environments, matching the
+ * gate in mu-plugins/load.php) and the WP Document Revisions plugin is loaded.
  */
 
-if (
-    defined('S3_UPLOADS_BUCKET') &&
-    S3_UPLOADS_BUCKET &&
-    getenv('WP_ENVIRONMENT_TYPE') !== 'local'
-) {
+add_action('plugins_loaded', function () {
+    if (
+        !class_exists('WP_Document_Revisions') ||
+        !defined('S3_UPLOADS_BUCKET') ||
+        !S3_UPLOADS_BUCKET ||
+        getenv('WP_ENVIRONMENT_TYPE') === 'local'
+    ) {
+        return;
+    }
+
     add_filter(
         'pre_site_option_document_upload_directory',
         fn () => 's3://' . S3_UPLOADS_BUCKET . '/uploads/sites/%site_id%'
     );
-}
+});

--- a/opt/php/wpdr-document-upload-dir.php
+++ b/opt/php/wpdr-document-upload-dir.php
@@ -13,15 +13,13 @@
  * the container. Filtering the site option short-circuits that lookup.
  *
  * Only active when s3-uploads is in play (non-local environments,
- * matching the gate in mu-plugins/load.php) and WP Document Revisions
- * is loaded.
+ * matching the gate in mu-plugins/load.php). The filter only takes effect
+ * when something reads the document_upload_directory site option, which in
+ * practice is only WP Document Revisions, so no explicit plugin check is
+ * needed.
  */
 
-if (
-    defined('S3_UPLOADS_BUCKET') &&
-    S3_UPLOADS_BUCKET &&
-    getenv('WP_ENVIRONMENT_TYPE') !== 'local'
-) {
+if (defined('S3_UPLOADS_BUCKET') && S3_UPLOADS_BUCKET) {
     add_filter(
         'pre_site_option_document_upload_directory',
         fn () => 's3://' . S3_UPLOADS_BUCKET . '/uploads/sites/%site_id%'

--- a/opt/php/wpdr-document-upload-dir.php
+++ b/opt/php/wpdr-document-upload-dir.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Plugin Name: WPDR Document Upload Dir (S3)
+ * Description: Point wp-document-revisions at the s3-uploads bucket so document
+ * file paths resolve via the s3:// stream wrapper instead of a stale local
+ * basedir cached in wpdr's constructor before s3-uploads filters upload_dir.
+ *
+ * Only active when s3-uploads is in play (i.e. non-local environments, matching
+ * the gate in mu-plugins/load.php).
+ */
+
+if (
+    defined('S3_UPLOADS_BUCKET') &&
+    S3_UPLOADS_BUCKET &&
+    getenv('WP_ENVIRONMENT_TYPE') !== 'local'
+) {
+    add_filter(
+        'pre_site_option_document_upload_directory',
+        fn () => 's3://' . S3_UPLOADS_BUCKET . '/uploads/sites/%site_id%'
+    );
+}

--- a/opt/php/wpdr-document-upload-dir.php
+++ b/opt/php/wpdr-document-upload-dir.php
@@ -1,27 +1,29 @@
 <?php
 
 /**
- * Plugin Name: WPDR Document Upload Dir (S3)
- * Description: Point wp-document-revisions at the s3-uploads bucket so document
- * file paths resolve via the s3:// stream wrapper instead of a stale local
- * basedir cached in wpdr's constructor before s3-uploads filters upload_dir.
+ * WPDR Document Upload Dir (S3)
  *
- * Only active when s3-uploads is in play (non-local environments, matching the
- * gate in mu-plugins/load.php) and the WP Document Revisions plugin is loaded.
+ * Forces wp-document-revisions to resolve document paths through the
+ * s3:// stream wrapper by filtering the `document_upload_directory`
+ * site option directly.
+ *
+ * wpdr's constructor reads wp_upload_dir() and caches the basedir before
+ * s3-uploads has registered its `upload_dir` filter, so without this
+ * override wpdr writes documents to a local path that doesn't exist in
+ * the container. Filtering the site option short-circuits that lookup.
+ *
+ * Only active when s3-uploads is in play (non-local environments,
+ * matching the gate in mu-plugins/load.php) and WP Document Revisions
+ * is loaded.
  */
 
-add_action('plugins_loaded', function () {
-    if (
-        !class_exists('WP_Document_Revisions') ||
-        !defined('S3_UPLOADS_BUCKET') ||
-        !S3_UPLOADS_BUCKET ||
-        getenv('WP_ENVIRONMENT_TYPE') === 'local'
-    ) {
-        return;
-    }
-
+if (
+    defined('S3_UPLOADS_BUCKET') &&
+    S3_UPLOADS_BUCKET &&
+    getenv('WP_ENVIRONMENT_TYPE') !== 'local'
+) {
     add_filter(
         'pre_site_option_document_upload_directory',
         fn () => 's3://' . S3_UPLOADS_BUCKET . '/uploads/sites/%site_id%'
     );
-});
+}

--- a/wordpress.dockerfile
+++ b/wordpress.dockerfile
@@ -38,6 +38,7 @@ RUN addgroup -g 1001 wp \
 # Add PHP multsite supporting files
 COPY opt/php/load.php /usr/src/wordpress/wp-content/mu-plugins/load.php
 COPY opt/php/application.php /usr/src/wordpress/wp-content/mu-plugins/application.php
+COPY opt/php/wpdr-document-upload-dir.php /usr/src/wordpress/wp-content/mu-plugins/wpdr-document-upload-dir.php
 COPY opt/php/error-handling.php /usr/src/wordpress/error-handling.php
 COPY opt/php/www.conf /usr/local/etc/php-fpm.d/www.conf
 COPY opt/php/wp-cron-multisite.php /usr/src/wordpress/wp-cron-multisite.php


### PR DESCRIPTION
### Problem

On non-local environments, wp-document-revisions writes document files to a local filesystem path that doesn't exist in the container, instead of going through the `s3://` stream wrapper provided by s3-uploads.

The cause is hook ordering: wpdr's constructor calls `wp_upload_dir()` and caches the resulting `basedir` before s3-uploads has registered its `upload_dir` filter. Once cached, every subsequent document write uses the stale local path.

### Fix

Filter `pre_site_option_document_upload_directory` directly to short-circuit wpdr's option lookup and force document paths through the `s3://` stream wrapper, pointing at the same per-site uploads location s3-uploads uses (`uploads/sites/%site_id%`).

- `pre_site_option_*` filters short-circuit the option lookup entirely, so wpdr never sees the stale cached value.
- The `%site_id%` placeholder is resolved by wpdr per subsite, so this works correctly across the multisite.
- Gated on `S3_UPLOADS_BUCKET` being defined and a non-local environment, matching the existing s3-uploads gate in `mu-plugins/load.php`. On local, document uploads continue to use the standard local path.
- No `class_exists('WP_Document_Revisions')` check needed: the filtered option name is wpdr-specific, so the filter is a no-op when wpdr isn't loaded.