### PR TITLE
Local dev performance enhancements

### DIFF
--- a/bin/local-build.sh
+++ b/bin/local-build.sh
@@ -26,6 +26,12 @@ while true; do
                 rm -rf $DIR
             fi
 
+            # Remove the shared WP core volume so the entrypoint of the new
+            # image repopulates core files on next start. Containers must be
+            # stopped first or the volume is in use. DB volume is untouched.
+            docker compose --profile firewall down --remove-orphans 2>/dev/null
+            docker volume rm -f hale-platform_wpcore 2>/dev/null || true
+
             # Determine the path for the .env file and create file. Do not overwrite if .env exists.
             ENV_FILE_PATH="$(pwd)/.env"
 

--- a/composer.lock
+++ b/composer.lock
@@ -115,16 +115,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.387.1",
+            "version": "3.387.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "2e1a16e9c87f2a069aa8a0a14a314dd148de21e1"
+                "reference": "dac6a19ffc71e6d100f06098e7df58f2e27103f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/2e1a16e9c87f2a069aa8a0a14a314dd148de21e1",
-                "reference": "2e1a16e9c87f2a069aa8a0a14a314dd148de21e1",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/dac6a19ffc71e6d100f06098e7df58f2e27103f9",
+                "reference": "dac6a19ffc71e6d100f06098e7df58f2e27103f9",
                 "shasum": ""
             },
             "require": {
@@ -206,9 +206,9 @@
             "support": {
                 "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.387.1"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.387.2"
             },
-            "time": "2026-07-01T18:10:42+00:00"
+            "time": "2026-07-02T18:06:18+00:00"
         },
         {
             "name": "clue/stream-filter",

--- a/composer.lock
+++ b/composer.lock
@@ -115,16 +115,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.385.0",
+            "version": "3.387.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "994e3408fb963ead9e1ba8ff1a751aa039bfbdf1"
+                "reference": "2e1a16e9c87f2a069aa8a0a14a314dd148de21e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/994e3408fb963ead9e1ba8ff1a751aa039bfbdf1",
-                "reference": "994e3408fb963ead9e1ba8ff1a751aa039bfbdf1",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/2e1a16e9c87f2a069aa8a0a14a314dd148de21e1",
+                "reference": "2e1a16e9c87f2a069aa8a0a14a314dd148de21e1",
                 "shasum": ""
             },
             "require": {
@@ -206,9 +206,9 @@
             "support": {
                 "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.385.0"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.387.1"
             },
-            "time": "2026-06-16T23:06:51+00:00"
+            "time": "2026-07-01T18:10:42+00:00"
         },
         {
             "name": "clue/stream-filter",
@@ -490,26 +490,26 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.12.0",
+            "version": "7.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "eaa81598031cf57a9e36258c8546defffc994cba"
+                "reference": "55901a76dfd2006a0cc012b9e3c5b487f796478d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/eaa81598031cf57a9e36258c8546defffc994cba",
-                "reference": "eaa81598031cf57a9e36258c8546defffc994cba",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/55901a76dfd2006a0cc012b9e3c5b487f796478d",
+                "reference": "55901a76dfd2006a0cc012b9e3c5b487f796478d",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "guzzlehttp/promises": "^2.5",
-                "guzzlehttp/psr7": "^2.12",
+                "guzzlehttp/psr7": "^2.12.3",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
-                "symfony/polyfill-php80": "^1.24"
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -518,7 +518,7 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.2",
-                "guzzlehttp/test-server": "^0.5",
+                "guzzlehttp/test-server": "^0.6",
                 "php-http/message-factory": "^1.1",
                 "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
@@ -598,7 +598,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.12.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.13.1"
             },
             "funding": [
                 {
@@ -614,7 +614,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-16T22:11:48+00:00"
+            "time": "2026-06-29T20:14:18+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -702,16 +702,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.12.0",
+            "version": "2.12.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "9b38012e7b54f594707e6db52c684dc0a74b3a43"
+                "reference": "7ec62dc3f44aa218487dbed81a9bf9bc647be55d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/9b38012e7b54f594707e6db52c684dc0a74b3a43",
-                "reference": "9b38012e7b54f594707e6db52c684dc0a74b3a43",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7ec62dc3f44aa218487dbed81a9bf9bc647be55d",
+                "reference": "7ec62dc3f44aa218487dbed81a9bf9bc647be55d",
                 "shasum": ""
             },
             "require": {
@@ -720,7 +720,7 @@
                 "psr/http-message": "^1.1 || ^2.0",
                 "ralouphie/getallheaders": "^3.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
-                "symfony/polyfill-php80": "^1.24"
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -801,7 +801,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.12.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.12.3"
             },
             "funding": [
                 {
@@ -817,7 +817,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-16T21:50:11+00:00"
+            "time": "2026-06-23T15:21:08+00:00"
         },
         {
             "name": "http-interop/http-factory-guzzle",
@@ -971,12 +971,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ministryofjustice/govwind.git",
-                "reference": "58bc5ee246d696336c2b41af25cbe93ee5ee8436"
+                "reference": "2b95c336430a2b9041377c491d9a1c077d6262ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ministryofjustice/govwind/zipball/58bc5ee246d696336c2b41af25cbe93ee5ee8436",
-                "reference": "58bc5ee246d696336c2b41af25cbe93ee5ee8436",
+                "url": "https://api.github.com/repos/ministryofjustice/govwind/zipball/2b95c336430a2b9041377c491d9a1c077d6262ad",
+                "reference": "2b95c336430a2b9041377c491d9a1c077d6262ad",
                 "shasum": ""
             },
             "default-branch": true,
@@ -986,7 +986,7 @@
                 "source": "https://github.com/ministryofjustice/govwind/tree/main",
                 "issues": "https://github.com/ministryofjustice/govwind/issues"
             },
-            "time": "2026-06-12T11:43:43+00:00"
+            "time": "2026-06-29T14:53:05+00:00"
         },
         {
             "name": "ministryofjustice/hale",
@@ -1088,12 +1088,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ministryofjustice/justice.git",
-                "reference": "6b901d764a3ffbc599fb10469953a8456b4c60ba"
+                "reference": "0abdaba443265a89261fc86a10ff4a73b2a3d079"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ministryofjustice/justice/zipball/6b901d764a3ffbc599fb10469953a8456b4c60ba",
-                "reference": "6b901d764a3ffbc599fb10469953a8456b4c60ba",
+                "url": "https://api.github.com/repos/ministryofjustice/justice/zipball/0abdaba443265a89261fc86a10ff4a73b2a3d079",
+                "reference": "0abdaba443265a89261fc86a10ff4a73b2a3d079",
                 "shasum": ""
             },
             "default-branch": true,
@@ -1103,7 +1103,7 @@
                 "source": "https://github.com/ministryofjustice/justice/tree/main",
                 "issues": "https://github.com/ministryofjustice/justice/issues"
             },
-            "time": "2026-06-17T17:15:52+00:00"
+            "time": "2026-06-25T08:24:58+00:00"
         },
         {
             "name": "ministryofjustice/ppo",
@@ -1134,12 +1134,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ministryofjustice/website-builder-blocks.git",
-                "reference": "de8149c991630fad48380d6e961b6ac5c1d3e56d"
+                "reference": "9f43248adc48b0a7d1a69a1f8d6d7bf2d681f5ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ministryofjustice/website-builder-blocks/zipball/de8149c991630fad48380d6e961b6ac5c1d3e56d",
-                "reference": "de8149c991630fad48380d6e961b6ac5c1d3e56d",
+                "url": "https://api.github.com/repos/ministryofjustice/website-builder-blocks/zipball/9f43248adc48b0a7d1a69a1f8d6d7bf2d681f5ac",
+                "reference": "9f43248adc48b0a7d1a69a1f8d6d7bf2d681f5ac",
                 "shasum": ""
             },
             "require-dev": {
@@ -1164,10 +1164,10 @@
             ],
             "description": "WP plugin that adds addtional blocks.",
             "support": {
-                "source": "https://github.com/ministryofjustice/website-builder-blocks/tree/main",
+                "source": "https://github.com/ministryofjustice/website-builder-blocks/tree/2.0.1",
                 "issues": "https://github.com/ministryofjustice/website-builder-blocks/issues"
             },
-            "time": "2026-06-15T13:10:00+00:00"
+            "time": "2026-06-30T15:40:57+00:00"
         },
         {
             "name": "ministryofjustice/wp-gov-uk-notify",
@@ -2464,16 +2464,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
-                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d",
                 "shasum": ""
             },
             "require": {
@@ -2511,7 +2511,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -2531,7 +2531,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-13T15:52:40+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -2606,16 +2606,16 @@
         },
         {
             "name": "symfony/http-client",
-            "version": "v7.4.13",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client.git",
-                "reference": "e8a112b8415707265a7e614278136a9d92989a6a"
+                "reference": "f6bc6b5a54ff5afac4725cacec9bf2f52eb15920"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/e8a112b8415707265a7e614278136a9d92989a6a",
-                "reference": "e8a112b8415707265a7e614278136a9d92989a6a",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/f6bc6b5a54ff5afac4725cacec9bf2f52eb15920",
+                "reference": "f6bc6b5a54ff5afac4725cacec9bf2f52eb15920",
                 "shasum": ""
             },
             "require": {
@@ -2683,7 +2683,7 @@
                 "http"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client/tree/v7.4.13"
+                "source": "https://github.com/symfony/http-client/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -2703,20 +2703,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-24T09:57:54+00:00"
+            "time": "2026-06-16T11:50:14+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client-contracts.git",
-                "reference": "4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d"
+                "reference": "41fc42d276aeff21192465331ebbab7d83a743c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d",
-                "reference": "4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/41fc42d276aeff21192465331ebbab7d83a743c0",
+                "reference": "41fc42d276aeff21192465331ebbab7d83a743c0",
                 "shasum": ""
             },
             "require": {
@@ -2765,7 +2765,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/http-client-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -2785,7 +2785,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-06T13:17:50+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/options-resolver",
@@ -3257,16 +3257,16 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a"
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d25d82433a80eba6aa0e6c24b61d7370d99e444a",
-                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/c0a284bab1ed8aa0417e3d69250ab437739563a0",
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0",
                 "shasum": ""
             },
             "require": {
@@ -3320,7 +3320,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -3340,7 +3340,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-28T09:44:51+00:00"
+            "time": "2026-06-16T09:55:08+00:00"
         },
         {
             "name": "tigitz/php-spellchecker",
@@ -3615,15 +3615,15 @@
         },
         {
             "name": "wpackagist-plugin/cms-tree-page-view",
-            "version": "1.6.8",
+            "version": "1.7.1",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/cms-tree-page-view/",
-                "reference": "tags/1.6.8"
+                "reference": "tags/1.7.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/cms-tree-page-view.1.6.8.zip"
+                "url": "https://downloads.wordpress.org/plugin/cms-tree-page-view.1.7.1.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -3723,15 +3723,15 @@
         },
         {
             "name": "wpackagist-plugin/revisionary",
-            "version": "3.8.2",
+            "version": "3.8.3",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/revisionary/",
-                "reference": "tags/3.8.2"
+                "reference": "tags/3.8.3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/revisionary.3.8.2.zip"
+                "url": "https://downloads.wordpress.org/plugin/revisionary.3.8.3.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -3903,10 +3903,10 @@
         },
         {
             "name": "wpengine/advanced-custom-fields-pro",
-            "version": "6.8.4",
+            "version": "6.8.5",
             "dist": {
                 "type": "zip",
-                "url": "https://connect.advancedcustomfields.com/v2/plugins/composer_download?s=composer&p=pro&t=6.8.4"
+                "url": "https://connect.advancedcustomfields.com/v2/plugins/composer_download?s=composer&p=pro&t=6.8.5"
             },
             "require": {
                 "composer/installers": "~1.0 || ~2.0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - ./opt/nginx/localwordpress.conf:/usr/local/openresty/nginx/conf/conf.d/localwordpress.conf
       - ./opt/lua/firewall.lua:/usr/local/openresty/nginx/lua/firewall.lua
       - ./opt/lua/firewall:/usr/local/openresty/nginx/lua/firewall
+      - ./opt/lua/pagecache:/usr/local/openresty/nginx/lua/pagecache
       - ./bin/certs:/etc/nginx/certs/self-signed/
     depends_on:
       - wordpress
@@ -24,6 +25,7 @@ services:
       VIRTUAL_HOST: hale.docker
       VIRTUAL_PORT: 443
       FIREWALL_ENABLED: ${FIREWALL_ENABLED:-false}
+      PAGECACHE_ENABLED: ${PAGECACHE_ENABLED:-false}
       REDIS_SSL: "false"
   mariadb:
     container_name: mariadb
@@ -81,11 +83,13 @@ services:
       ACF_PRO_LICENSE: ""
       NGINX_INTERNAL_URL: "https://nginx"
       FIREWALL_ENABLED: ${FIREWALL_ENABLED:-false}
+      PAGECACHE_ENABLED: ${PAGECACHE_ENABLED:-false}
       REDIS_SSL: "false"
   redis:
     image: redis:7-alpine
     profiles:
     - firewall
+    - pagecache
     ports:
       - 127.0.0.1:6379:6379
     volumes:
@@ -94,6 +98,7 @@ services:
     image: redis/redisinsight:3.4
     profiles:
     - firewall
+    - pagecache
     environment:
       VIRTUAL_PORT: 5540
       VIRTUAL_HOST: redis-insight.docker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,12 @@ services:
       - 8080:8080
       - 443:443
     volumes:
-      - ./wordpress:/var/www/html:delegated
+      # WP core lives in the shared wpcore volume (fast, native to the Docker
+      # VM); only wp-content is bind-mounted from the host so edits to themes,
+      # plugins and uploads are picked up. Core is populated into the volume
+      # by the wordpress container entrypoint on first start.
+      - wpcore:/var/www/html
+      - ./wordpress/wp-content:/var/www/html/wp-content
       - ./dev:/mnt/dev:delegated
       - ./opt/nginx/nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf
       - ./opt/nginx/localwordpress.conf:/usr/local/openresty/nginx/conf/conf.d/localwordpress.conf
@@ -50,7 +55,8 @@ services:
       context: .
       dockerfile: wordpress.local.dockerfile
     volumes:
-      - ./wordpress:/var/www/html:delegated
+      - wpcore:/var/www/html
+      - ./wordpress/wp-content:/var/www/html/wp-content
       - ./dev:/mnt/dev:delegated
       - ./opt/scripts:/opt/scripts:delegated
       - ./opt/php/php-local.ini:/usr/local/etc/php/conf.d/zz-local.ini
@@ -108,4 +114,8 @@ volumes:
   database:
     driver: local
   redis:
+    driver: local
+  # WordPress core files, shared between nginx and wordpress containers.
+  # Removed by bin/local-build.sh on rebuild so a new image repopulates core.
+  wpcore:
     driver: local

--- a/helm_deploy/wordpress/templates/configmap.yaml
+++ b/helm_deploy/wordpress/templates/configmap.yaml
@@ -9,6 +9,8 @@ data:
   S3_UPLOADS_USE_INSTANCE_PROFILE: {{ .Values.configmap.s3useprofile | quote }}
   PHP_DSN: {{ .Values.configmap.sentrydns }}
   FIREWALL_ENABLED: {{ .Values.configmap.firewall.enabled | quote }}
+  PAGECACHE_ENABLED: {{ .Values.configmap.pagecache.enabled | quote }}
+  PAGECACHE_TTL: {{ .Values.configmap.pagecache.ttl | quote }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -16,3 +18,5 @@ metadata:
   name: hale-nginx-config-{{ .Release.Revision }}
 data:
   FIREWALL_ENABLED: {{ .Values.configmap.firewall.enabled | quote }}
+  PAGECACHE_ENABLED: {{ .Values.configmap.pagecache.enabled | quote }}
+  PAGECACHE_TTL: {{ .Values.configmap.pagecache.ttl | quote }}

--- a/helm_deploy/wordpress/values.yaml
+++ b/helm_deploy/wordpress/values.yaml
@@ -144,6 +144,10 @@ configmap:
   sentrydns: ""
   firewall:
     enabled: "true"
+  # Full-page cache (OpenResty + Redis). Ships dark: enable per environment.
+  pagecache:
+    enabled: "false"
+    ttl: "300"
 
 
 ## @param secrets passed in via GitActions

--- a/makefile
+++ b/makefile
@@ -2,8 +2,7 @@
 ### Local build config
 ####################################################
 
-.PHONY: run down build shell none clone-repos symlink logs restart clean help
-
+.PHONY: run down build shell none clone-repos symlink logs restart clean help test-firewall
 # Default target - show help
 help:
 	@echo "Available commands:"

--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -23,6 +23,7 @@ COPY opt/nginx/wordpress.conf      /usr/local/openresty/nginx/conf/conf.d/
 COPY opt/nginx/justice/            /usr/local/openresty/nginx/conf/justice/
 COPY opt/lua/firewall.lua          /usr/local/openresty/nginx/lua/firewall.lua
 COPY opt/lua/firewall              /usr/local/openresty/nginx/lua/firewall
+COPY opt/lua/pagecache             /usr/local/openresty/nginx/lua/pagecache
 COPY opt/nginx/error-pages/        /usr/local/openresty/nginx/html/error-pages/
 
 # Switch to non-root user (must use numeric UID for K8s runAsNonRoot verification)

--- a/nginx.local.dockerfile
+++ b/nginx.local.dockerfile
@@ -29,6 +29,7 @@ COPY opt/nginx/nginx.conf          /usr/local/openresty/nginx/conf/nginx.conf
 COPY opt/nginx/localwordpress.conf /usr/local/openresty/nginx/conf/conf.d/
 COPY opt/lua/firewall.lua          /usr/local/openresty/nginx/lua/firewall.lua
 COPY opt/lua/firewall              /usr/local/openresty/nginx/lua/firewall
+COPY opt/lua/pagecache             /usr/local/openresty/nginx/lua/pagecache
 COPY opt/nginx/error-pages/        /usr/local/openresty/nginx/html/error-pages/
 
 # Switch to non-root user (numeric UID for consistency with production)

--- a/opt/lua/pagecache/init.lua
+++ b/opt/lua/pagecache/init.lua
@@ -1,0 +1,184 @@
+-- ============================================================================
+-- FULL-PAGE CACHE (OpenResty + Redis)
+-- ============================================================================
+-- Serves cached HTML straight from Redis (db1), skipping PHP entirely on a HIT.
+-- Shared across ALL pods (unlike nginx's per-pod fastcgi_cache, which this
+-- replaces). Invalidated per-URL by the WordPress purge mu-plugin on publish.
+--
+-- Wiring (in the `location ~ \.php$` block):
+--   access_by_lua   -> pagecache.fetch()         serve HIT, or flag MISS to store
+--   header_filter   -> pagecache.filter_headers()decide if the response is storeable
+--   body_filter     -> pagecache.capture_body()  buffer the HTML (no cosocket here)
+--   log_by_lua      -> pagecache.store()         persist to Redis via a 0-delay timer
+--
+-- Fail-open everywhere: any Redis problem just means PHP serves the request.
+--
+-- KEY SCHEME (must match the WP purge mu-plugin):
+--   pagecache:v{version}:{host}:{request_uri}
+--   - {host} isolates multisite sites; {version} bumps for an instant mass flush.
+--   - scheme is deliberately omitted: TLS is terminated upstream, so the scheme
+--     nginx sees can differ from what WordPress sees. Host + path is canonical.
+-- ============================================================================
+
+local redis_pool = require "pagecache.redis"
+
+local _M = {}
+
+local ENABLED     = os.getenv("PAGECACHE_ENABLED") == "true"
+local TTL         = tonumber(os.getenv("PAGECACHE_TTL")) or 300
+local MAX_BYTES   = tonumber(os.getenv("PAGECACHE_MAX_BYTES")) or (2 * 1024 * 1024)
+local PREFIX      = "pagecache:"
+local VERSION_KEY = "pagecache:version"
+local DEFAULT_CT  = "text/html; charset=UTF-8"
+
+-- Request URIs that must never be cached (admin, auth, API, cron, feeds...).
+-- request_uri is the ORIGINAL url, before the internal rewrite to index.php.
+local BYPASS_URI = {
+    "/wp%-admin", "/wp%-login", "/wp%-json", "/xmlrpc%.php",
+    "wp%-cron", "/feed", "sitemap",
+}
+
+-- Request cookies that mean "personalised" — logged in, commenter, password.
+local BYPASS_COOKIE = {
+    "wordpress_logged_in", "wordpress_[a-f0-9]+", "comment_author",
+    "wp%-postpass", "wordpress_no_cache",
+}
+
+-- $pagecache_status is a map var (declared in the *.conf files), surfaced in the
+-- access log so HIT/MISS/BYPASS is visible per request.
+local function set_status(s)
+    ngx.var.pagecache_status = s
+end
+
+-- Is this REQUEST eligible to read/write the page cache?
+local function request_cacheable()
+    if ngx.req.get_method() ~= "GET" then return false end
+    if (ngx.var.args or "") ~= "" then return false end   -- query string -> dynamic
+
+    local uri = ngx.var.request_uri or ""
+    for _, pat in ipairs(BYPASS_URI) do
+        if uri:find(pat) then return false end
+    end
+
+    local cookie = ngx.var.http_cookie
+    if cookie then
+        for _, pat in ipairs(BYPASS_COOKIE) do
+            if cookie:find(pat) then return false end
+        end
+    end
+    return true
+end
+
+local function build_key(red)
+    local ver = red:get(VERSION_KEY)
+    if ver == ngx.null or not ver then ver = "0" end
+    return PREFIX .. "v" .. ver .. ":" .. ngx.var.host .. ":" .. ngx.var.request_uri
+end
+
+
+-- ============================================================================
+-- fetch(): access phase. Serve a HIT, or flag the request to be stored on MISS.
+-- ============================================================================
+function _M.fetch()
+    if not ENABLED then set_status("off"); return end
+    if not request_cacheable() then set_status("bypass"); return end
+
+    local red = redis_pool.connect()
+    if not red then set_status("down"); return end       -- fail-open -> PHP
+
+    local key  = build_key(red)
+    local blob = red:get(key)
+    if blob == ngx.null or not blob then
+        redis_pool.release(red)
+        ngx.ctx.pc_key   = key                           -- remember for store phase
+        ngx.ctx.pc_store = true
+        set_status("miss")
+        return
+    end
+    redis_pool.release(red)
+
+    -- Stored blob = "<content-type>\n<body>". Split on the first newline.
+    local nl   = blob:find("\n", 1, true)
+    local ct   = nl and blob:sub(1, nl - 1) or DEFAULT_CT
+    local body = nl and blob:sub(nl + 1) or blob
+
+    ngx.header["Content-Type"] = ct
+    ngx.header["X-Page-Cache"] = "HIT"
+    set_status("hit")
+    ngx.print(body)
+    ngx.exit(ngx.HTTP_OK)
+end
+
+
+-- ============================================================================
+-- filter_headers(): header phase. Confirm the RESPONSE is safe to cache.
+-- ============================================================================
+function _M.filter_headers()
+    if not ngx.ctx.pc_store then return end
+
+    local ct = ngx.header["Content-Type"] or ""
+    local cc = ngx.header["Cache-Control"] or ""
+    if ngx.status ~= 200
+        or not ct:find("text/html", 1, true)
+        or ngx.header["Set-Cookie"]                       -- personalised response
+        or ngx.header["Content-Encoding"]                 -- store uncompressed only
+        or cc:find("no%-cache") or cc:find("no%-store") or cc:find("private")
+    then
+        ngx.ctx.pc_store = false
+        return
+    end
+    ngx.ctx.pc_ct = ct
+    ngx.header["X-Page-Cache"] = "MISS"
+end
+
+
+-- ============================================================================
+-- capture_body(): body phase. Buffer the HTML. No cosocket (Redis) allowed here.
+-- ============================================================================
+function _M.capture_body()
+    if not ngx.ctx.pc_store then return end
+
+    local buf = ngx.ctx.pc_buf
+    if not buf then buf = {}; ngx.ctx.pc_buf = buf; ngx.ctx.pc_len = 0 end
+
+    local chunk = ngx.arg[1]
+    if chunk and chunk ~= "" then
+        ngx.ctx.pc_len = ngx.ctx.pc_len + #chunk
+        if ngx.ctx.pc_len > MAX_BYTES then                -- too big: give up storing
+            ngx.ctx.pc_store = false
+            ngx.ctx.pc_buf = nil
+            return
+        end
+        buf[#buf + 1] = chunk
+    end
+end
+
+
+-- Timer callback: the actual Redis write (cosockets are allowed in timers).
+local function write_to_redis(premature, key, ct, body)
+    if premature then return end
+    local red = redis_pool.connect()
+    if not red then return end
+    -- SETEX guarantees a TTL on every key -> eligible for volatile-lru eviction,
+    -- so the shared instance can never evict the firewall's persistent keys.
+    red:setex(key, TTL, ct .. "\n" .. body)
+    redis_pool.release(red)
+end
+
+
+-- ============================================================================
+-- store(): log phase. Schedule the Redis write once the response is sent.
+-- ============================================================================
+function _M.store()
+    if not ngx.ctx.pc_store or not ngx.ctx.pc_buf then return end
+    local body = table.concat(ngx.ctx.pc_buf)
+    if body == "" then return end
+
+    local ok, err = ngx.timer.at(0, write_to_redis,
+        ngx.ctx.pc_key, ngx.ctx.pc_ct or DEFAULT_CT, body)
+    if not ok then
+        ngx.log(ngx.ERR, "[pagecache] store timer failed: ", err)
+    end
+end
+
+return _M

--- a/opt/lua/pagecache/init.lua
+++ b/opt/lua/pagecache/init.lua
@@ -14,10 +14,19 @@
 -- Fail-open everywhere: any Redis problem just means PHP serves the request.
 --
 -- KEY SCHEME (must match the WP purge mu-plugin):
---   pagecache:v{version}:{host}:{request_uri}
+--   pagecache:v{version}:{host}:{request_uri}          content key
+--   pagecache:fence:{host}:{request_uri}                purge fence (no version)
 --   - {host} isolates multisite sites; {version} bumps for an instant mass flush.
 --   - scheme is deliberately omitted: TLS is terminated upstream, so the scheme
 --     nginx sees can differ from what WordPress sees. Host + path is canonical.
+--
+-- PURGE/WRITE RACE: a request that MISSes can still be mid-render when an
+-- editor publishes and the purge plugin deletes that path's cache entry.
+-- The deferred Redis write (after the response is sent) would otherwise
+-- re-cache that now-stale render straight into the just-purged key. The
+-- fence key closes this: the purge stamps it with the current Redis time,
+-- and the deferred write only commits if no fence was stamped at/after the
+-- time this request started rendering (see write_to_redis/CAS_WRITE_SCRIPT).
 -- ============================================================================
 
 local redis_pool = require "pagecache.redis"
@@ -75,6 +84,25 @@ local function build_key(red)
     return PREFIX .. "v" .. ver .. ":" .. ngx.var.host .. ":" .. ngx.var.request_uri
 end
 
+-- Fence key for this path. Unversioned and shared with the WP purge plugin,
+-- which must build this exact same key from $host/$path.
+local function build_fence_key()
+    return PREFIX .. "fence:" .. ngx.var.host .. ":" .. ngx.var.request_uri
+end
+
+-- Atomic check-and-write: refuse to cache a render if a purge fence for this
+-- path was stamped at or after the time this request started rendering.
+-- That means a purge happened mid-render, so the buffered body may be stale.
+local CAS_WRITE_SCRIPT = [[
+local fence = redis.call('GET', KEYS[2])
+if fence and tonumber(fence) and tonumber(ARGV[3])
+   and tonumber(fence) >= tonumber(ARGV[3]) then
+    return 0
+end
+redis.call('SETEX', KEYS[1], ARGV[1], ARGV[2])
+return 1
+]]
+
 
 -- ============================================================================
 -- fetch(): access phase. Serve a HIT, or flag the request to be stored on MISS.
@@ -89,9 +117,19 @@ function _M.fetch()
     local key  = build_key(red)
     local blob = red:get(key)
     if blob == ngx.null or not blob then
+        -- Snapshot Redis's own clock (not local wall-clock - avoids drift
+        -- across pods) so the deferred write can tell if a purge landed
+        -- after this request started rendering.
+        local time_ok, time_res = pcall(function() return red:time() end)
+        local started = nil
+        if time_ok and type(time_res) == "table" and time_res[1] then
+            started = tostring(time_res[1]) .. "." .. tostring(time_res[2] or "0")
+        end
         redis_pool.release(red)
-        ngx.ctx.pc_key   = key                           -- remember for store phase
-        ngx.ctx.pc_store = true
+        ngx.ctx.pc_key     = key                         -- remember for store phase
+        ngx.ctx.pc_fence   = build_fence_key()
+        ngx.ctx.pc_started = started
+        ngx.ctx.pc_store   = true
         set_status("miss")
         return
     end
@@ -155,13 +193,32 @@ end
 
 
 -- Timer callback: the actual Redis write (cosockets are allowed in timers).
-local function write_to_redis(premature, key, ct, body)
+--
+-- Fenced write: if `started` is set, the write only commits when no purge
+-- fence for this path was stamped at or after `started`. A fence at/after
+-- that time means a purge happened mid-render, so `body` may be stale -
+-- the write is silently dropped rather than re-caching old content.
+-- Check + write happen in one EVAL so there's no gap between them.
+local function write_to_redis(premature, key, fence_key, started, ct, body)
     if premature then return end
     local red = redis_pool.connect()
     if not red then return end
-    -- SETEX guarantees a TTL on every key -> eligible for volatile-lru eviction,
-    -- so the shared instance can never evict the firewall's persistent keys.
-    red:setex(key, TTL, ct .. "\n" .. body)
+
+    local value = ct .. "\n" .. body
+    if started and fence_key then
+        -- SETEX guarantees a TTL on every key -> eligible for volatile-lru
+        -- eviction, so the shared instance can never evict the firewall's
+        -- persistent keys. (Done inside the script too - see CAS_WRITE_SCRIPT.)
+        local ok, err = red:eval(CAS_WRITE_SCRIPT, 2, key, fence_key, TTL, value, started)
+        if not ok then
+            ngx.log(ngx.ERR, "[pagecache] fenced write failed: ", err)
+        end
+    else
+        -- No snapshot time available (e.g. Redis TIME failed earlier) -
+        -- fall back to an unfenced write rather than dropping the cache
+        -- entirely. Rare; only happens on a partial Redis failure.
+        red:setex(key, TTL, value)
+    end
     redis_pool.release(red)
 end
 
@@ -175,7 +232,8 @@ function _M.store()
     if body == "" then return end
 
     local ok, err = ngx.timer.at(0, write_to_redis,
-        ngx.ctx.pc_key, ngx.ctx.pc_ct or DEFAULT_CT, body)
+        ngx.ctx.pc_key, ngx.ctx.pc_fence, ngx.ctx.pc_started,
+        ngx.ctx.pc_ct or DEFAULT_CT, body)
     if not ok then
         ngx.log(ngx.ERR, "[pagecache] store timer failed: ", err)
     end

--- a/opt/lua/pagecache/redis.lua
+++ b/opt/lua/pagecache/redis.lua
@@ -1,0 +1,103 @@
+-- ============================================================================
+-- PAGE CACHE REDIS CONNECTION POOL
+-- ============================================================================
+-- Dedicated Redis pool for the full-page cache. Mirrors firewall/redis.lua but
+-- targets a SEPARATE logical database (default db1) and a SEPARATE connection
+-- pool name, so page-cache sockets can never be handed to the firewall (which
+-- uses db0 and the default pool) or vice versa.
+--
+-- Fail-open: if Redis is down, connect() returns nil and callers must let the
+-- request fall through to PHP. A cache outage must never take the site down.
+--
+-- CONFIGURATION (env vars; connection settings shared with the firewall):
+--   REDIS_HOST          - Redis hostname (default: "redis")
+--   REDIS_PORT          - Redis port (default: 6379)
+--   REDIS_AUTH          - Redis password (default: none)
+--   REDIS_SSL           - Use TLS (default: true, set "false" to disable)
+--   PAGECACHE_DB        - Logical db index for the page cache (default: 1)
+--   REDIS_POOL_SIZE     - Max connections per worker (default: 25)
+--   REDIS_KEEPALIVE_MS  - Idle connection timeout in ms (default: 10000)
+-- ============================================================================
+
+local _M = {}
+
+local REDIS_HOST = os.getenv("REDIS_HOST") or "redis"
+local REDIS_PORT = tonumber(os.getenv("REDIS_PORT")) or 6379
+local REDIS_AUTH = os.getenv("REDIS_AUTH")
+local REDIS_SSL  = os.getenv("REDIS_SSL") ~= "false"
+
+-- Page cache lives in its own logical DB so a page-cache FLUSHDB can never
+-- wipe the firewall rules in db0.
+local PAGECACHE_DB = tonumber(os.getenv("PAGECACHE_DB")) or 1
+
+local REDIS_TIMEOUT      = 200
+local REDIS_POOL_SIZE    = tonumber(os.getenv("REDIS_POOL_SIZE")) or 25
+local REDIS_KEEPALIVE_MS = tonumber(os.getenv("REDIS_KEEPALIVE_MS")) or 10000
+
+-- Distinct pool name keeps db1 sockets out of the firewall's default (db0)
+-- pool. Without this, a reused socket could still be SELECTed on the wrong DB.
+local POOL_NAME = "pagecache_db" .. PAGECACHE_DB
+
+
+-- ============================================================================
+-- connect(): Create and connect a Redis client (fail-open -> nil on error).
+-- ============================================================================
+function _M.connect()
+    local redis = require "resty.redis"
+
+    local red = redis:new()
+    red:set_timeout(REDIS_TIMEOUT)
+
+    local ok, err
+    if REDIS_SSL then
+        ok, err = red:connect(REDIS_HOST, REDIS_PORT,
+            { ssl = true, ssl_verify = true, pool = POOL_NAME })
+    else
+        ok, err = red:connect(REDIS_HOST, REDIS_PORT, { pool = POOL_NAME })
+    end
+    if not ok then
+        ngx.log(ngx.ERR, "[pagecache] connect failed (fail-open): ", err)
+        return nil
+    end
+
+    if REDIS_AUTH and REDIS_AUTH ~= "" then
+        local auth_ok, auth_err = red:auth(REDIS_AUTH)
+        if not auth_ok then
+            ngx.log(ngx.ERR, "[pagecache] auth failed (fail-open): ", auth_err)
+            red:close()
+            return nil
+        end
+    end
+
+    -- Always SELECT: this pool must never operate on db0 (the firewall's DB).
+    local sel_ok, sel_err = red:select(PAGECACHE_DB)
+    if not sel_ok then
+        ngx.log(ngx.ERR, "[pagecache] select db failed (fail-open): ", sel_err)
+        red:close()
+        return nil
+    end
+
+    return red
+end
+
+
+-- ============================================================================
+-- release(): Return the connection to the (named) keepalive pool.
+-- ============================================================================
+function _M.release(red)
+    if red then
+        red:set_keepalive(REDIS_KEEPALIVE_MS, REDIS_POOL_SIZE)
+    end
+end
+
+
+-- Exported for logging/debugging.
+_M.config = {
+    host = REDIS_HOST,
+    port = REDIS_PORT,
+    ssl  = REDIS_SSL,
+    db   = PAGECACHE_DB,
+    pool = POOL_NAME,
+}
+
+return _M

--- a/opt/nginx/localwordpress.conf
+++ b/opt/nginx/localwordpress.conf
@@ -17,6 +17,12 @@ map $blogname $blogid{
 map $host $firewall_info {
     default "-";
 }
+# Page cache status ("hit"/"miss"/"bypass"/"off"/"down") — set by the page cache
+# Lua module and surfaced in the access log. A `map` (not `set`) for the same
+# reason as $firewall_info above.
+map $host $pagecache_status {
+    default "-";
+}
 server {
     listen 8080 default_server;
     listen [::]:8080 default_server;
@@ -68,9 +74,11 @@ server {
         try_files $uri $uri/ /index.php?$args;
     }
     location ~ \.php$ {
-        # Firewall: check bans, score request
+        # Firewall: check bans, score request. Page cache: serve a HIT from Redis
+        # (skips PHP entirely), otherwise flag the request to be stored on MISS.
         access_by_lua_block {
             require("firewall").req()
+            require("pagecache").fetch()
         }
 
         try_files $uri =404;
@@ -83,9 +91,18 @@ server {
         proxy_send_timeout 1000s;
         proxy_read_timeout 1000s;
 
-        # Firewall: penalize bad responses
+        # Page cache: decide if the response is storeable, then buffer the HTML.
+        header_filter_by_lua_block {
+            require("pagecache").filter_headers()
+        }
+        body_filter_by_lua_block {
+            require("pagecache").capture_body()
+        }
+
+        # Firewall: penalize bad responses. Page cache: persist the HTML to Redis.
         log_by_lua_block {
             require("firewall").res()
+            require("pagecache").store()
         }
     }
     # Static files - Added CSS, JS, and other web assets

--- a/opt/nginx/nginx.conf
+++ b/opt/nginx/nginx.conf
@@ -25,6 +25,12 @@ env REDIS_DB;
 env REDIS_POOL_SIZE;
 env REDIS_KEEPALIVE_MS;
 
+# Page cache settings
+env PAGECACHE_ENABLED;
+env PAGECACHE_TTL;
+env PAGECACHE_DB;
+env PAGECACHE_MAX_BYTES;
+
 # Firewall settings
 env FIREWALL_ENABLED;
 env ENV;
@@ -104,7 +110,7 @@ http {
         log_format main '$remote_addr - $remote_user [$time_local] '
                         '"$request" $status $body_bytes_sent '
                         '"$http_referer" "$http_user_agent" '
-                        'fw_info=$firewall_info cache=$upstream_cache_status';
+                        'fw_info=$firewall_info pc=$pagecache_status';
 
 
         # Suppress successful cron requests — wp-cron.php and wp-cron-multisite.php

--- a/opt/nginx/wordpress.conf
+++ b/opt/nginx/wordpress.conf
@@ -17,11 +17,12 @@ map $blogname $blogid{
 map $host $firewall_info {
     default "-";
 }
-# FastCGI Cache config
-fastcgi_cache_path /usr/local/openresty/nginx/cache levels=1:2 keys_zone=WPCACHE:100m inactive=60m;
-fastcgi_cache_key "$scheme$request_method$host$request_uri";
-fastcgi_cache_use_stale error timeout invalid_header http_500;
-fastcgi_ignore_headers Cache-Control Expires Set-Cookie;
+# Page cache status ("hit"/"miss"/"bypass"/"off"/"down") — set by the page cache
+# Lua module and surfaced in the access log. A `map` (not `set`) for the same
+# reason as $firewall_info above.
+map $host $pagecache_status {
+    default "-";
+}
 server {
     listen 8080 default_server;
     listen [::]:8080 default_server;
@@ -46,24 +47,10 @@ server {
     
     # FastCGI request buffering
     fastcgi_request_buffering off;
-    
-    # Caching
-    set $skip_cache 0;
-        # POST requests and urls with a query string should always go to PHP
-    if ($request_method = POST) {
-        set $skip_cache 1;
-    }
-    if ($query_string != "") {
-        set $skip_cache 1;
-    }
-    # Don't cache uris containing the following segments
-    if ($request_uri ~* "/wp-admin/|/xmlrpc.php|wp-.*.php|/feed/|index.php|sitemap(_index)?.xml") {
-        set $skip_cache 1;
-    }
-    # Don't use the cache for logged in users or recent commenters
-    if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in") {
-        set $skip_cache 1;
-    }
+
+    # Page cache bypass rules (request method, query string, admin/auth URIs,
+    # logged-in cookies) live in the Lua module: opt/lua/pagecache/init.lua.
+
     location ~ ^(/[^/]+)?/files/(.+) {
         try_files /wp-content/blogs.dir/$blogid/files/$2 /wp-includes/ms-files.php?file=$2;
         access_log off;
@@ -89,9 +76,11 @@ server {
         try_files $uri $uri/ /index.php?$args;
     }
     location ~ \.php$ {
-        # Firewall: check bans, score request
+        # Firewall: check bans, score request. Page cache: serve a HIT from Redis
+        # (skips PHP entirely), otherwise flag the request to be stored on MISS.
         access_by_lua_block {
             require("firewall").req()
+            require("pagecache").fetch()
         }
 
         include fastcgi_params;
@@ -101,23 +90,22 @@ server {
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_pass wordpress;
         fastcgi_hide_header X-Powered-By;
-        fastcgi_cache_bypass $skip_cache;
-        fastcgi_no_cache $skip_cache;
-        fastcgi_cache WPCACHE;
-        fastcgi_cache_valid 200 60m;
         fastcgi_read_timeout 600;
-        add_header X-FastCGI-Cache $upstream_cache_status;
 
-        # Firewall: penalize bad responses
+        # Page cache: decide if the response is storeable, then buffer the HTML.
+        header_filter_by_lua_block {
+            require("pagecache").filter_headers()
+        }
+        body_filter_by_lua_block {
+            require("pagecache").capture_body()
+        }
+
+        # Firewall: penalize bad responses. Page cache: persist the HTML to Redis.
         log_by_lua_block {
             require("firewall").res()
+            require("pagecache").store()
         }
     }
-    # Activate once nginx purge module has been installed
-    #location ~ /purge(/.*) {
-    #    fastcgi_cache_purge WPCACHE "$scheme$request_method$host$1";
-    #}
-    
     # Video files - handle separately for streaming support
     # We currently use a CDN so this tecnically is not used but I have left it here
     # so that our nginx config at least supports it

--- a/opt/php/hale-pagecache-purge.php
+++ b/opt/php/hale-pagecache-purge.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Plugin Name: Hale page cache purge
+ * Description: Clears the OpenResty/Redis full-page cache when a page or post
+ *              goes live - manual publish, scheduled publish (WP-Cron), or an
+ *              edit to already-published content. Page cache ONLY; this never
+ *              touches any object cache.
+ *
+ * Why transition_post_status (not save_post): save_post does NOT fire when
+ * WP-Cron publishes a scheduled post. transition_post_status fires for manual
+ * publish, scheduled publish, and edits of already-live content.
+ */
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+add_action('transition_post_status', 'hale_pagecache_on_transition', 10, 3);
+
+/**
+ * @param string  $new_status
+ * @param string  $old_status
+ * @param WP_Post $post
+ */
+function hale_pagecache_on_transition($new_status, $old_status, $post): void
+{
+    // Only act when the result is a live, publicly viewable page/post.
+    if ('publish' !== $new_status) {
+        return;
+    }
+    if (wp_is_post_revision($post) || wp_is_post_autosave($post)) {
+        return;
+    }
+    if (! is_post_type_viewable(get_post_type($post))) {
+        return;
+    }
+
+    // URLs whose cached HTML is now stale.
+    $paths   = ['/'];                                       // home lists/links new content
+    $paths[] = hale_pagecache_path(get_permalink($post));
+
+    // Hierarchical pages: ancestors show breadcrumbs / child listings.
+    foreach (get_post_ancestors($post) as $ancestor_id) {
+        $paths[] = hale_pagecache_path(get_permalink($ancestor_id));
+    }
+
+    hale_pagecache_purge_paths(array_values(array_unique(array_filter($paths))));
+}
+
+/**
+ * Reduce a full permalink to the path used in the cache key (e.g. "/about/").
+ */
+function hale_pagecache_path($url): string
+{
+    $path = wp_parse_url((string) $url, PHP_URL_PATH);
+    return $path ?: '/';
+}
+
+/**
+ * DELETE the page-cache keys for the given paths on the current site.
+ *
+ * Fail-soft: any Redis error is logged and swallowed so a cache problem can
+ * never block an editor from publishing.
+ *
+ * @param string[] $paths
+ */
+function hale_pagecache_purge_paths(array $paths): void
+{
+    if ('true' !== getenv('PAGECACHE_ENABLED') || empty($paths)) {
+        return;
+    }
+    if (! class_exists('Redis')) {
+        error_log('pagecache purge: phpredis (Redis class) not available');
+        return;
+    }
+
+    try {
+        $host = getenv('REDIS_HOST') ?: 'redis';
+        $port = (int) (getenv('REDIS_PORT') ?: 6379);
+
+        // ElastiCache in-transit encryption needs the tls:// scheme.
+        // Local dev sets REDIS_SSL=false.
+        if ('false' !== getenv('REDIS_SSL')) {
+            $host = 'tls://' . $host;
+        }
+
+        $redis = new Redis();
+        if (! $redis->connect($host, $port, 1.0)) {
+            error_log('pagecache purge: Redis connect failed');
+            return;
+        }
+        if ($auth = getenv('REDIS_AUTH')) {
+            $redis->auth($auth);
+        }
+        // Page cache lives in its own DB; the firewall is db0.
+        $redis->select((int) (getenv('PAGECACHE_DB') ?: 1));
+
+        $version  = (int) ($redis->get('pagecache:version') ?: 0);
+        $hostname = wp_parse_url(home_url(), PHP_URL_HOST);   // multisite: scope to this site
+
+        foreach ($paths as $path) {
+            // Must match the Lua key scheme: pagecache:v{ver}:{host}:{uri}
+            $redis->del("pagecache:v{$version}:{$hostname}:{$path}");
+        }
+
+        $redis->close();
+    } catch (\Throwable $t) {
+        error_log('pagecache purge failed: ' . $t->getMessage());
+    }
+}

--- a/opt/php/hale-pagecache-purge.php
+++ b/opt/php/hale-pagecache-purge.php
@@ -57,7 +57,18 @@ function hale_pagecache_path($url): string
 }
 
 /**
- * DELETE the page-cache keys for the given paths on the current site.
+ * DELETE the page-cache keys for the given paths on the current site, and
+ * stamp a purge fence for each path so an in-flight request that started
+ * rendering before this purge can't re-cache stale content afterward.
+ *
+ * RACE THIS CLOSES: a request can MISS and start rendering a path right
+ * before an editor publishes. The Lua cache layer writes that render to
+ * Redis asynchronously, *after* the response is already sent - which can
+ * land after this DEL runs and silently undo the purge with stale HTML.
+ * The fence key (pagecache:fence:{host}:{path}, stamped with Redis's own
+ * clock) lets that deferred write check "was this path purged after I
+ * started?" and skip its own write if so. See opt/lua/pagecache/init.lua
+ * (write_to_redis / CAS_WRITE_SCRIPT) for the other half of this.
  *
  * Fail-soft: any Redis error is logged and swallowed so a cache problem can
  * never block an editor from publishing.
@@ -98,9 +109,33 @@ function hale_pagecache_purge_paths(array $paths): void
         $version  = (int) ($redis->get('pagecache:version') ?: 0);
         $hostname = wp_parse_url(home_url(), PHP_URL_HOST);   // multisite: scope to this site
 
+        // Fence TTL must outlive the slowest realistic PHP render so a
+        // very slow in-flight request can still be fenced out. 60s is
+        // comfortably above normal render times; raise it if pages are
+        // known to render slower than that.
+        $fenceTtl = (int) (getenv('PAGECACHE_FENCE_TTL') ?: 60);
+
+        // Redis's own clock, not the web server's wall-clock - avoids
+        // clock drift between this PHP host and the OpenResty pods.
+        $time       = $redis->rawCommand('TIME');
+        $fenceValue = (is_array($time) && isset($time[0]))
+            ? $time[0] . '.' . ($time[1] ?? '0')
+            : null;
+
         foreach ($paths as $path) {
-            // Must match the Lua key scheme: pagecache:v{ver}:{host}:{uri}
-            $redis->del("pagecache:v{$version}:{$hostname}:{$path}");
+            // Must match the Lua key schemes:
+            //   content key -> pagecache:v{ver}:{host}:{uri}
+            //   fence key   -> pagecache:fence:{host}:{uri}   (unversioned)
+            $contentKey = "pagecache:v{$version}:{$hostname}:{$path}";
+            $fenceKey   = "pagecache:fence:{$hostname}:{$path}";
+
+            if (null !== $fenceValue) {
+                $redis->set($fenceKey, $fenceValue, ['EX' => $fenceTtl]);
+            } else {
+                error_log('pagecache purge: Redis TIME unavailable, fence not set for ' . $path);
+            }
+
+            $redis->del($contentKey);
         }
 
         $redis->close();

--- a/opt/php/php-local.ini
+++ b/opt/php/php-local.ini
@@ -1,9 +1,14 @@
-; --- Disable OPcache entirely for local development ---
-opcache.enable=0
+; --- OPcache on for local development ---
+; validate_timestamps=1 + revalidate_freq=0 means file changes are picked up
+; immediately (mtime checked every request) while compiled code stays cached.
+opcache.enable=1
 opcache.enable_cli=0
 opcache.validate_timestamps=1
 opcache.revalidate_freq=0
 opcache.save_comments=1
+opcache.memory_consumption=256
+opcache.interned_strings_buffer=32
+opcache.max_accelerated_files=20000
 
 ; --- Disable JIT (improves rebuild consistency) ---
 opcache.jit=0
@@ -14,4 +19,3 @@ display_errors=1
 display_startup_errors=1
 error_reporting=E_ALL
 log_errors=1
-

--- a/wordpress.dockerfile
+++ b/wordpress.dockerfile
@@ -41,6 +41,7 @@ RUN addgroup -g 1001 wp \
 COPY opt/php/load.php /usr/src/wordpress/wp-content/mu-plugins/load.php
 COPY opt/php/application.php /usr/src/wordpress/wp-content/mu-plugins/application.php
 COPY opt/php/wpdr-document-upload-dir.php /usr/src/wordpress/wp-content/mu-plugins/wpdr-document-upload-dir.php
+COPY opt/php/hale-pagecache-purge.php /usr/src/wordpress/wp-content/mu-plugins/hale-pagecache-purge.php
 COPY opt/php/error-handling.php /usr/src/wordpress/error-handling.php
 COPY opt/php/www.conf /usr/local/etc/php-fpm.d/www.conf
 COPY opt/php/wp-cron-multisite.php /usr/src/wordpress/wp-cron-multisite.php

--- a/wordpress.local.dockerfile
+++ b/wordpress.local.dockerfile
@@ -39,6 +39,7 @@ RUN addgroup -g 1001 wp \
 # Add PHP multsite supporting files
 COPY opt/php/load.php /usr/src/wordpress/wp-content/mu-plugins/load.php
 COPY opt/php/application.php /usr/src/wordpress/wp-content/mu-plugins/application.php
+COPY opt/php/hale-pagecache-purge.php /usr/src/wordpress/wp-content/mu-plugins/hale-pagecache-purge.php
 COPY opt/php/error-handling.php /usr/src/wordpress/error-handling.php
 COPY opt/php/www.local.conf /usr/local/etc/php-fpm.d/www.conf
 COPY opt/php/wp-cron-multisite.php /usr/src/wordpress/wp-cron-multisite.php

--- a/wordpress.local.dockerfile
+++ b/wordpress.local.dockerfile
@@ -5,7 +5,9 @@
 # ##################################################
 # Build multisite
 # Latest images at https://hub.docker.com/_/wordpress
-FROM --platform=linux/amd64 wordpress:6.9.4-php8.4-fpm-alpine
+# No platform pin: local image matches host architecture (arm64 on Apple
+# Silicon) to avoid emulation. Production (wordpress.dockerfile) stays amd64.
+FROM wordpress:6.9.4-php8.4-fpm-alpine
 
 # Install additional Alpine packages
 RUN apk update && \


### PR DESCRIPTION
I've noticed quite a sluggish dev experience lately with the multisite, so I've attempted here to make some improvements. I've tested these and they do seem to make everything load 

Changes

- opt/php/php-local.ini — OPcache enabled with validate_timestamps=1 + revalidate_freq=0: compiled code cached, file edits still picked up instantly. JIT stays off.

- wordpress.local.dockerfile — dropped --platform=linux/amd64 from FROM; local image now builds native arm64. Prod wordpress.dockerfile untouched. I think we are all on the same thing now.

- docker-compose.yml — Trying this out, WP core now lives in shared wpcore named volume (native Docker-VM speed) mounted into both nginx and wordpress; only ./wordpress/wp-content bind-mounted from macOS. Core is auto-populated by the official entrypoint on first start (it explicitly supports the "wp-content persisted separately" pattern).

- bin/local-build.sh — rebuild now also stops containers and removes the wpcore volume so a new image version repopulates core. Database volume untouched.


Tip: 

In Docker config, change in General settings to Use Rosetta for x86_64/amd64 emulation on Apple Silicon.
