### PR TITLE
[DO NOT MERGE] Update Justice canary weight to 100

### DIFF
--- a/helm_deploy/wordpress/templates/ingress-justice.yaml
+++ b/helm_deploy/wordpress/templates/ingress-justice.yaml
@@ -113,7 +113,7 @@ metadata:
     # Marks the Ingress as part of a canary deployment.
     nginx.ingress.kubernetes.io/canary: "true"
     # Defines the traffic weight for the canary (NGINX level).
-    nginx.ingress.kubernetes.io/canary-weight: "0"
+    nginx.ingress.kubernetes.io/canary-weight: "100"
     nginx.ingress.kubernetes.io/canary-by-cookie: 'X-Canary'
     nginx.ingress.kubernetes.io/canary-by-header: 'X-Canary'
 spec:


### PR DESCRIPTION
## DO NOT MERGE YET

---

This PR will send all traffic for www.justice.gov.uk to WB platform.

It should be applied only after review and approval from the WB team and editor team.