### PR TITLE
Update core to 7.0.3

### DIFF
--- a/wordpress.dockerfile
+++ b/wordpress.dockerfile
@@ -53,10 +53,6 @@ RUN addgroup -g 1001 wp \
     && adduser -G wp -g wp -s /bin/sh -D wp \
     && chown wp:wp /var/www/html
 
-# Create the non-root runtime user early so COPY --chown can assign ownership
-# at write time, avoiding a slow recursive chown over the whole tree later.
-RUN adduser --disabled-password hale -u 1002
-
 # Add PHP multsite supporting files
 COPY opt/php/load.php /usr/src/wordpress/wp-content/mu-plugins/load.php
 COPY opt/php/application.php /usr/src/wordpress/wp-content/mu-plugins/application.php
@@ -73,18 +69,18 @@ COPY opt/scripts/startup-patch.sh /usr/local/bin/
 # Generated Composer and NPM compiled artifacts (plugins, themes, CSS, JS)
 # The WP offical Docker image expects files to be in /usr/src/wordpress
 # but then will copy them over on launch of site to the /html directory.
-COPY --chown=hale:hale /wordpress/wp-content/plugins /usr/src/wordpress/wp-content/plugins
-COPY --chown=hale:hale /wordpress/wp-content/mu-plugins /usr/src/wordpress/wp-content/mu-plugins
-COPY --chown=hale:hale /wordpress/wp-content/themes /usr/src/wordpress/wp-content/themes
-COPY --chown=hale:hale /vendor /usr/src/wordpress/wp-content/vendor
+COPY /wordpress/wp-content/plugins /usr/src/wordpress/wp-content/plugins
+COPY /wordpress/wp-content/mu-plugins /usr/src/wordpress/wp-content/mu-plugins
+COPY /wordpress/wp-content/themes /usr/src/wordpress/wp-content/themes
+COPY /vendor /usr/src/wordpress/wp-content/vendor
 
 # Load default production php.ini file in
 # Custom php.ini additions for dev, staging & prod are done via k8s manifest
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
-# Set ownership for the non-root runtime user (hale created above).
-# /usr/src/wordpress content is already owned by hale via COPY --chown.
-RUN chown -R hale:hale /var/www/html \
+# Create new user to run the container as non-root
+RUN adduser --disabled-password hale -u 1002 \
+    && chown -R hale:hale /var/www/html \
     && chown hale:hale /usr/local/bin/docker-entrypoint.sh
 
 # Make multisite scripts executable

--- a/wordpress.dockerfile
+++ b/wordpress.dockerfile
@@ -38,7 +38,6 @@ RUN set -ex; \
 	if [ -n "$PATCH_WORDPRESS_VERSION" ] && [ -n "$PATCH_WORDPRESS_SHA1" ]; then \
 		curl -o wordpress.tar.gz -fL "https://wordpress.org/wordpress-$PATCH_WORDPRESS_VERSION.tar.gz"; \
 		echo "$PATCH_WORDPRESS_SHA1 *wordpress.tar.gz" | sha1sum -c -; \
-		rm -rf /usr/src/wordpress; \
 		tar -xzf wordpress.tar.gz -C /usr/src/; \
 		rm wordpress.tar.gz; \
         chown -R www-data:www-data /usr/src/wordpress; \

--- a/wordpress.dockerfile
+++ b/wordpress.dockerfile
@@ -38,7 +38,7 @@ RUN set -ex; \
 	if [ -n "$PATCH_WORDPRESS_VERSION" ] && [ -n "$PATCH_WORDPRESS_SHA1" ]; then \
 		curl -o wordpress.tar.gz -fL "https://wordpress.org/wordpress-$PATCH_WORDPRESS_VERSION.tar.gz"; \
 		echo "$PATCH_WORDPRESS_SHA1 *wordpress.tar.gz" | sha1sum -c -; \
-		\
+		rm -rf /usr/src/wordpress; \
 		tar -xzf wordpress.tar.gz -C /usr/src/; \
 		rm wordpress.tar.gz; \
         chown -R www-data:www-data /usr/src/wordpress; \

--- a/wordpress.dockerfile
+++ b/wordpress.dockerfile
@@ -28,6 +28,23 @@ RUN pecl install redis \
 # Delete PHPRedis build dependencies
 RUN apk del .build-deps
 
+# Install a patched version of WordPress core, prior to release on Docker Hub.
+# Minimal implementation, edit the following 2 arguments directly.
+ARG PATCH_WORDPRESS_VERSION="7.0.3"
+# Get value from https://wordpress.org/wordpress-<WORDPRESS_VERSION>.tar.gz.sha1
+ARG PATCH_WORDPRESS_SHA1="344b74d7cbf13c55ba0f12cad207c06cfee4368a"
+# Download and extract script from: https://github.com/docker-library/wordpress/blob/master/Dockerfile.template
+RUN set -ex; \
+	if [ -n "$PATCH_WORDPRESS_VERSION" ] && [ -n "$PATCH_WORDPRESS_SHA1" ]; then \
+		curl -o wordpress.tar.gz -fL "https://wordpress.org/wordpress-$PATCH_WORDPRESS_VERSION.tar.gz"; \
+		echo "$PATCH_WORDPRESS_SHA1 *wordpress.tar.gz" | sha1sum -c -; \
+		\
+		tar -xzf wordpress.tar.gz -C /usr/src/; \
+		rm wordpress.tar.gz; \
+        chown -R www-data:www-data /usr/src/wordpress; \
+        echo "Patched WordPress core to $PATCH_WORDPRESS_VERSION"; \
+	fi
+
 # Install wp-cli
 RUN curl -o /usr/local/bin/wp https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar && \
     chmod +x /usr/local/bin/wp

--- a/wordpress.dockerfile
+++ b/wordpress.dockerfile
@@ -81,6 +81,7 @@ RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 # Create new user to run the container as non-root
 RUN adduser --disabled-password hale -u 1002 \
     && chown -R hale:hale /var/www/html \
+    && chown -R hale:hale /usr/src/wordpress \
     && chown hale:hale /usr/local/bin/docker-entrypoint.sh
 
 # Make multisite scripts executable

--- a/wordpress.dockerfile
+++ b/wordpress.dockerfile
@@ -54,6 +54,10 @@ RUN addgroup -g 1001 wp \
     && adduser -G wp -g wp -s /bin/sh -D wp \
     && chown wp:wp /var/www/html
 
+# Create the non-root runtime user early so COPY --chown can assign ownership
+# at write time, avoiding a slow recursive chown over the whole tree later.
+RUN adduser --disabled-password hale -u 1002
+
 # Add PHP multsite supporting files
 COPY opt/php/load.php /usr/src/wordpress/wp-content/mu-plugins/load.php
 COPY opt/php/application.php /usr/src/wordpress/wp-content/mu-plugins/application.php
@@ -70,19 +74,18 @@ COPY opt/scripts/startup-patch.sh /usr/local/bin/
 # Generated Composer and NPM compiled artifacts (plugins, themes, CSS, JS)
 # The WP offical Docker image expects files to be in /usr/src/wordpress
 # but then will copy them over on launch of site to the /html directory.
-COPY /wordpress/wp-content/plugins /usr/src/wordpress/wp-content/plugins
-COPY /wordpress/wp-content/mu-plugins /usr/src/wordpress/wp-content/mu-plugins
-COPY /wordpress/wp-content/themes /usr/src/wordpress/wp-content/themes
-COPY /vendor /usr/src/wordpress/wp-content/vendor
+COPY --chown=hale:hale /wordpress/wp-content/plugins /usr/src/wordpress/wp-content/plugins
+COPY --chown=hale:hale /wordpress/wp-content/mu-plugins /usr/src/wordpress/wp-content/mu-plugins
+COPY --chown=hale:hale /wordpress/wp-content/themes /usr/src/wordpress/wp-content/themes
+COPY --chown=hale:hale /vendor /usr/src/wordpress/wp-content/vendor
 
 # Load default production php.ini file in
 # Custom php.ini additions for dev, staging & prod are done via k8s manifest
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
-# Create new user to run the container as non-root
-RUN adduser --disabled-password hale -u 1002 \
-    && chown -R hale:hale /var/www/html \
-    && chown -R hale:hale /usr/src/wordpress \
+# Set ownership for the non-root runtime user (hale created above).
+# /usr/src/wordpress content is already owned by hale via COPY --chown.
+RUN chown -R hale:hale /var/www/html \
     && chown hale:hale /usr/local/bin/docker-entrypoint.sh
 
 # Make multisite scripts executable

--- a/wordpress.local.dockerfile
+++ b/wordpress.local.dockerfile
@@ -54,10 +54,6 @@ RUN addgroup -g 1001 wp \
     && adduser -G wp -g wp -s /bin/sh -D wp \
     && chown wp:wp /var/www/html
 
-# Create the non-root runtime user early so COPY --chown can assign ownership
-# at write time, avoiding a slow recursive chown over the whole tree later.
-RUN adduser --disabled-password hale -u 1002
-
 # Add PHP multsite supporting files
 COPY opt/php/load.php /usr/src/wordpress/wp-content/mu-plugins/load.php
 COPY opt/php/application.php /usr/src/wordpress/wp-content/mu-plugins/application.php
@@ -73,17 +69,18 @@ COPY opt/scripts/startup-patch.sh /usr/local/bin/
 # Generated Composer and NPM compiled artifacts (plugins, themes, CSS, JS)
 # The WP offical Docker image expects files to be in /usr/src/wordpress
 # but then will copy them over on launch of site to the /html directory.
-COPY --chown=hale:hale /wordpress/wp-content/plugins /usr/src/wordpress/wp-content/plugins
-COPY --chown=hale:hale /wordpress/wp-content/mu-plugins /usr/src/wordpress/wp-content/mu-plugins
-COPY --chown=hale:hale /wordpress/wp-content/themes /usr/src/wordpress/wp-content/themes
-COPY --chown=hale:hale /vendor /usr/src/wordpress/wp-content/vendor
+COPY /wordpress/wp-content/plugins /usr/src/wordpress/wp-content/plugins
+COPY /wordpress/wp-content/mu-plugins /usr/src/wordpress/wp-content/mu-plugins
+COPY /wordpress/wp-content/themes /usr/src/wordpress/wp-content/themes
+COPY /vendor /usr/src/wordpress/wp-content/vendor
 
 # Load default production php.ini file in
 # Custom php.ini additions for dev, staging & prod are done via k8s manifest
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
-# Set ownership for the non-root runtime user (hale created above).
-RUN chown -R hale:hale /var/www/html \
+# Create new user to run the container as non-root
+RUN adduser --disabled-password hale -u 1002 \
+    && chown -R hale:hale /var/www/html \
     && chown hale:hale /usr/local/bin/docker-entrypoint.sh
 
 # Make multisite scripts executable

--- a/wordpress.local.dockerfile
+++ b/wordpress.local.dockerfile
@@ -55,6 +55,10 @@ RUN addgroup -g 1001 wp \
     && adduser -G wp -g wp -s /bin/sh -D wp \
     && chown wp:wp /var/www/html
 
+# Create the non-root runtime user early so COPY --chown can assign ownership
+# at write time, avoiding a slow recursive chown over the whole tree later.
+RUN adduser --disabled-password hale -u 1002
+
 # Add PHP multsite supporting files
 COPY opt/php/load.php /usr/src/wordpress/wp-content/mu-plugins/load.php
 COPY opt/php/application.php /usr/src/wordpress/wp-content/mu-plugins/application.php
@@ -70,18 +74,17 @@ COPY opt/scripts/startup-patch.sh /usr/local/bin/
 # Generated Composer and NPM compiled artifacts (plugins, themes, CSS, JS)
 # The WP offical Docker image expects files to be in /usr/src/wordpress
 # but then will copy them over on launch of site to the /html directory.
-COPY /wordpress/wp-content/plugins /usr/src/wordpress/wp-content/plugins
-COPY /wordpress/wp-content/mu-plugins /usr/src/wordpress/wp-content/mu-plugins
-COPY /wordpress/wp-content/themes /usr/src/wordpress/wp-content/themes
-COPY /vendor /usr/src/wordpress/wp-content/vendor
+COPY --chown=hale:hale /wordpress/wp-content/plugins /usr/src/wordpress/wp-content/plugins
+COPY --chown=hale:hale /wordpress/wp-content/mu-plugins /usr/src/wordpress/wp-content/mu-plugins
+COPY --chown=hale:hale /wordpress/wp-content/themes /usr/src/wordpress/wp-content/themes
+COPY --chown=hale:hale /vendor /usr/src/wordpress/wp-content/vendor
 
 # Load default production php.ini file in
 # Custom php.ini additions for dev, staging & prod are done via k8s manifest
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
-# Create new user to run the container as non-root
-RUN adduser --disabled-password hale -u 1002 \
-    && chown -R hale:hale /var/www/html \
+# Set ownership for the non-root runtime user (hale created above).
+RUN chown -R hale:hale /var/www/html \
     && chown hale:hale /usr/local/bin/docker-entrypoint.sh
 
 # Make multisite scripts executable

--- a/wordpress.local.dockerfile
+++ b/wordpress.local.dockerfile
@@ -81,7 +81,6 @@ RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 # Create new user to run the container as non-root
 RUN adduser --disabled-password hale -u 1002 \
     && chown -R hale:hale /var/www/html \
-    && chown -R hale:hale /usr/src/wordpress \
     && chown hale:hale /usr/local/bin/docker-entrypoint.sh
 
 # Make multisite scripts executable

--- a/wordpress.local.dockerfile
+++ b/wordpress.local.dockerfile
@@ -39,7 +39,6 @@ RUN set -ex; \
 	if [ -n "$PATCH_WORDPRESS_VERSION" ] && [ -n "$PATCH_WORDPRESS_SHA1" ]; then \
 		curl -o wordpress.tar.gz -fL "https://wordpress.org/wordpress-$PATCH_WORDPRESS_VERSION.tar.gz"; \
 		echo "$PATCH_WORDPRESS_SHA1 *wordpress.tar.gz" | sha1sum -c -; \
-		rm -rf /usr/src/wordpress; \
 		tar -xzf wordpress.tar.gz -C /usr/src/; \
 		rm wordpress.tar.gz; \
         chown -R www-data:www-data /usr/src/wordpress; \

--- a/wordpress.local.dockerfile
+++ b/wordpress.local.dockerfile
@@ -39,7 +39,7 @@ RUN set -ex; \
 	if [ -n "$PATCH_WORDPRESS_VERSION" ] && [ -n "$PATCH_WORDPRESS_SHA1" ]; then \
 		curl -o wordpress.tar.gz -fL "https://wordpress.org/wordpress-$PATCH_WORDPRESS_VERSION.tar.gz"; \
 		echo "$PATCH_WORDPRESS_SHA1 *wordpress.tar.gz" | sha1sum -c -; \
-		\
+		rm -rf /usr/src/wordpress; \
 		tar -xzf wordpress.tar.gz -C /usr/src/; \
 		rm wordpress.tar.gz; \
         chown -R www-data:www-data /usr/src/wordpress; \

--- a/wordpress.local.dockerfile
+++ b/wordpress.local.dockerfile
@@ -81,6 +81,7 @@ RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 # Create new user to run the container as non-root
 RUN adduser --disabled-password hale -u 1002 \
     && chown -R hale:hale /var/www/html \
+    && chown -R hale:hale /usr/src/wordpress \
     && chown hale:hale /usr/local/bin/docker-entrypoint.sh
 
 # Make multisite scripts executable

--- a/wordpress.local.dockerfile
+++ b/wordpress.local.dockerfile
@@ -29,6 +29,23 @@ RUN pecl install redis \
 # Delete PHPRedis build dependencies
 RUN apk del .build-deps
 
+# Install a patched version of WordPress core, prior to release on Docker Hub.
+# Minimal implementation, edit the following 2 arguments directly.
+ARG PATCH_WORDPRESS_VERSION="7.0.3"
+# Get value from https://wordpress.org/wordpress-<WORDPRESS_VERSION>.tar.gz.sha1
+ARG PATCH_WORDPRESS_SHA1="344b74d7cbf13c55ba0f12cad207c06cfee4368a"
+# Download and extract script from: https://github.com/docker-library/wordpress/blob/master/Dockerfile.template
+RUN set -ex; \
+	if [ -n "$PATCH_WORDPRESS_VERSION" ] && [ -n "$PATCH_WORDPRESS_SHA1" ]; then \
+		curl -o wordpress.tar.gz -fL "https://wordpress.org/wordpress-$PATCH_WORDPRESS_VERSION.tar.gz"; \
+		echo "$PATCH_WORDPRESS_SHA1 *wordpress.tar.gz" | sha1sum -c -; \
+		\
+		tar -xzf wordpress.tar.gz -C /usr/src/; \
+		rm wordpress.tar.gz; \
+        chown -R www-data:www-data /usr/src/wordpress; \
+        echo "Patched WordPress core to $PATCH_WORDPRESS_VERSION"; \
+	fi
+
 # Install wp-cli
 RUN curl -o /usr/local/bin/wp https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar && \
     chmod +x /usr/local/bin/wp


### PR DESCRIPTION
This PR utilises the work from 2 weeks ago in https://github.com/ministryofjustice/hale-platform/pull/463

This is because 7.0.3 is not yet available on docker hub.

~~Mote: also included, an optimisation of how the hale user is assigned ownership of folders.~~

~~Addresses a slow recursive chown command.~~

Available for review on dev environment.