### PR TITLE
Bump Govwind version to 1.0.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -101,7 +101,7 @@
   "require": {
     "composer/installers": "^v2.0",
     "ministryofjustice/cookie-compliance": "1.3.2",
-    "ministryofjustice/govwind": "1.0.2",
+    "ministryofjustice/govwind": "1.0.3",
     "ministryofjustice/justice": "dev-main",
     "ministryofjustice/hale": "4.35.1",
     "ministryofjustice/hale-components": "1.19.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4e3944fc701d96df8041768c5b008d50",
+    "content-hash": "dd8afe4164d0efd92b1fbd04c480a785",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -967,25 +967,25 @@
         },
         {
             "name": "ministryofjustice/govwind",
-            "version": "1.0.2",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ministryofjustice/govwind.git",
-                "reference": "4a4ee3edc2b732c7b251b6985ae5443defd03249"
+                "reference": "e7eccb5a9ba1470d1043c32098fc67038ced4297"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ministryofjustice/govwind/zipball/4a4ee3edc2b732c7b251b6985ae5443defd03249",
-                "reference": "4a4ee3edc2b732c7b251b6985ae5443defd03249",
+                "url": "https://api.github.com/repos/ministryofjustice/govwind/zipball/e7eccb5a9ba1470d1043c32098fc67038ced4297",
+                "reference": "e7eccb5a9ba1470d1043c32098fc67038ced4297",
                 "shasum": ""
             },
             "type": "wordpress-theme",
             "description": "Govwind theme",
             "support": {
-                "source": "https://github.com/ministryofjustice/govwind/tree/1.0.2",
+                "source": "https://github.com/ministryofjustice/govwind/tree/1.0.3",
                 "issues": "https://github.com/ministryofjustice/govwind/issues"
             },
-            "time": "2026-08-03T08:46:16+00:00"
+            "time": "2026-08-11T15:01:22+00:00"
         },
         {
             "name": "ministryofjustice/hale",


### PR DESCRIPTION
Updates the Govwind theme from 1.0.2 to 1.0.3

Changes:
-Updated ministryofjustice/govwind from 1.0.2 to 1.0.3 in composer.json.
-Updated composer.lock to reference the GovWind 1.0.3 release.